### PR TITLE
Signals issue

### DIFF
--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -314,6 +314,8 @@ class QuerySetMixin(object):
                 if cache_data is not None:
                     results = pickle.loads(cache_data)
                     for obj in results:
+                        signals.pre_init.send(sender=obj.__class__, *[], **obj.__dict__)
+                        signals.post_init.send(sender=obj.__class__, instance=obj)
                         yield obj
                     raise StopIteration
 


### PR DESCRIPTION
Signals were not corrently emited while calling pickle.load objects from cache. This commit fixies this problem by forcing signal emit

---

Когда объекты доставались из кэша и распаковывались из pickle-формата, не срабатывали init-сигналы. (В аналогочной ситуации без использования cacheops сигналы срабатывали). Коммит предлагает решение этой проблемы
