### PR TITLE
Handle caching and invalidation when Redis is unavailable

### DIFF
--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -26,18 +26,6 @@ except AttributeError:
     raise ImproperlyConfigured('You must specify non-empty CACHEOPS_REDIS setting to use cacheops')
 
 
-def auto_failover(func):
-
-    def _wrap(*args, **kwargs):
-        try:
-            func(*args, **kwargs)
-        except:
-            return None
-
-    return _wrap
-
-
-@auto_failover
 def get_redis_client():
     """
     Return redis cliend if connection could be established, other wise return None
@@ -49,6 +37,7 @@ redis_client = get_redis_client()
 
 
 model_profiles = {}
+
 
 def prepare_profiles():
     """


### PR DESCRIPTION
I have made simple solution for handle situation when Redis server is unavailable. If Redis works fine - use both caching and invalidation as well, if something wrong with Redis connection - instead of raise ConnectionError, for cache - uses qs within DB, for invalidation just skip invalidation and return None
