### PR TITLE
Added tests for Django 1.6 QuerySet.count() capability

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -89,3 +89,7 @@ class DbAgnostic(models.Model):
 class DbBinded(models.Model):
     pass
 
+
+# 54
+class Issue(models.Model):
+    pass

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -30,6 +30,7 @@ CACHEOPS = {
     'tests.local': ('just_enable', 60*60, {'local_get': True}),
     'tests.cacheonsavemodel': ('just_enable', 60*60, {'cache_on_save': True}),
     'tests.dbbinded': ('just_enable', 60*60, {'db_agnostic': False}),
+    'tests.issue': ('all', 60*60),
     '*.*': ('just_enable', 60*60),
 }
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,4 @@
-import unittest, random
+import unittest
 from django.test import TestCase
 from django.contrib.auth.models import User
 
@@ -104,7 +104,7 @@ class IssueTests(BaseTestCase):
             Profile.objects.cache().get(user=1)
 
     def test_29(self):
-        MachineBrand.objects.exclude(labels__in=[1,2,3]).cache().count()
+        MachineBrand.objects.exclude(labels__in=[1, 2, 3]).cache().count()
 
     def test_39(self):
         list(Point.objects.filter(x=7).cache())
@@ -115,6 +115,16 @@ class IssueTests(BaseTestCase):
 
         with self.assertNumQueries(0):
             CacheOnSaveModel.objects.cache().get(pk=m.pk)
+
+    def test_54(self):
+        issues = Issue.objects.all()
+
+        # force load objects to _result_cache
+        for issue in issues:
+            pass
+
+        # call count() via len() on _result_cache
+        issues.count()
 
 
 class LocalGetTests(BaseTestCase):


### PR DESCRIPTION
Tests for issue https://github.com/Suor/django-cacheops/issues/54

Its passes on Django<1.6
and fails on Django=1.6 with

```
ERROR: test_54 (tests.tests.IssueTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/hell/projects/django/django-cacheops/tests/tests.py", line 127, in test_54
    issues.count()
  File "/home/hell/projects/django/django-cacheops/cacheops/query.py", line 369, in count
    if self._result_cache is not None and not self._iter:
AttributeError: 'QuerySet' object has no attribute '_iter
```
