### PR TITLE
A PointField with a None value raises a "ValueError: Cannot use object w...

### DIFF
--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -94,8 +94,15 @@ NOT_SERIALIZED_FIELDS = (
     models.FileField,
     models.TextField, # One should not filter by long text equality
 )
+
 if hasattr(models, 'BinaryField'):
     NOT_SERIALIZED_FIELDS += (models.BinaryField,) # Not possible to filter by it
+
+try:
+    from django.contrib.gis.db import models as gis_models
+    NOT_SERIALIZED_FIELDS += (gis_models.PointField,)
+except Exception:
+    pass
 
 
 def dnfs(qs):

--- a/tests/models.py
+++ b/tests/models.py
@@ -9,7 +9,7 @@ from django.db.models import sql
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.contrib.auth.models import User
-
+from django.contrib.gis.db import models as gis_models
 
 ### For basic tests and bench
 
@@ -190,3 +190,6 @@ class GenericContainer(models.Model):
 class Contained(models.Model):
     name = models.CharField(max_length=30)
     containers = generic.GenericRelation(GenericContainer)
+
+class Geometry(gis_models.Model):
+    point = gis_models.PointField(geography=True, dim=3, blank=True, null=True, default=None)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -31,6 +31,23 @@ if os.environ.get('CACHEOPS_DB') == 'postgresql':
             'HOST': ''
         },
     }
+elif os.environ.get('CACHEOPS_DB') == 'postgis':
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.contrib.gis.db.backends.postgis',
+            'NAME': 'cacheops',
+            'USER': 'cacheops',
+            'PASSWORD': '',
+            'HOST': ''
+        },
+        'slave': {
+            'ENGINE': 'django.contrib.gis.db.backends.postgis',
+            'NAME': 'cacheops_slave',
+            'USER': 'cacheops',
+            'PASSWORD': '',
+            'HOST': ''
+        },
+    }
 else:
     DATABASES = {
         'default': {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -651,3 +651,12 @@ class DbAgnosticTests(BaseTestCase):
 
         with self.assertNumQueries(1, using='slave'):
             list(DbBinded.objects.cache().using('slave'))
+
+
+class GISTestCases(BaseTestCase):
+
+    def test_invalidate_model_with_geometry(self):
+        geom = Geometry()
+        geom.save()
+        # Raises ValueError if this doesn't work
+        invalidate_obj(geom)


### PR DESCRIPTION
...ith type NoneType for a geometry lookup parameter" error when trying to invalidate the object.

This was my quick and dirty fix... probably needs someone that understands the code better to tweak.
