### PR TITLE
Treat redis.TimeoutError the same as redis.ConnectionError when degrade.

### DIFF
--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -40,6 +40,8 @@ if DEGRADE_ON_FAILURE:
             return call()
         except redis.ConnectionError as e:
             warnings.warn("The cacheops cache is unreachable! Error: %s" % e, RuntimeWarning)
+        except redis.TimeoutError as e:
+            warnings.warn("The cacheops cache timed out! Error: %s" % e, RuntimeWarning)
 else:
     handle_connection_failure = identity
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -92,6 +92,7 @@ else:
     }
 
 CACHEOPS_LRU = bool(os.environ.get('CACHEOPS_LRU'))
+CACHEOPS_DEGRADE_ON_FAILURE = bool(os.environ.get('CACHEOPS_DEGRADE_ON_FAILURE'))
 ALLOWED_HOSTS = ['testserver']
 
 SECRET_KEY = 'abc'


### PR DESCRIPTION
Addresses issue #122 
