### PR TITLE
First implementation of dog-pile effect avoidance via python-redis-lock additions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -302,6 +302,26 @@ Combined with ``try ... finally`` it could be used to postpone invalidation:
 Postponing invalidation can considerably speed up batch jobs.
 
 
+Dog-pile effect avoidance
+-------------------------
+
+This package can benefit from `python-redis-lock` to avoid cache dog-pile
+effect (also known as the thundering herd effect or cache stampede). This
+feature is available in QuerySet cache and `@cached_as()`/`@cached_view_as()`
+decorators.
+
+Just define `CACHEOPS_USE_LOCK=True` in settings to make the `@cached`
+decorator protected against this issue.
+
+As it will use another redis call and depends on the creation of a network
+wide lock (that will affect eventual celery workers, etc), it's disabled
+by default.
+
+But the lock is only used on cache misses; there is no consequence on the
+read operations. Overall, this features shouldn't affect performances
+negatively in most cases, and should obviously reduce load on cache expiration.
+
+
 Using memory limit
 ------------------
 

--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -31,7 +31,7 @@ for key in profiles:
 
 LRU = getattr(settings, 'CACHEOPS_LRU', False)
 DEGRADE_ON_FAILURE = getattr(settings, 'CACHEOPS_DEGRADE_ON_FAILURE', False)
-
+USE_LOCK = getattr(settings, 'CACHEOPS_USE_LOCK', False)
 
 # Support DEGRADE_ON_FAILURE
 if DEGRADE_ON_FAILURE:

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'redis>=2.9.1',
         'funcy>=1.2,<2.0',
         'six>=1.4.0',
+        'python-redis-lock==2.0.0',
     ],
 
     classifiers=[

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -92,6 +92,7 @@ else:
     }
 
 CACHEOPS_LRU = bool(os.environ.get('CACHEOPS_LRU'))
+CACHEOPS_USE_LOCK = bool(os.environ.get('CACHEOPS_USE_LOCK'))
 CACHEOPS_DEGRADE_ON_FAILURE = bool(os.environ.get('CACHEOPS_DEGRADE_ON_FAILURE'))
 ALLOWED_HOSTS = ['testserver']
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ commands =
     ; Test with pre 2.2 style conf
     env CACHEOPS_CONF=old ./run_tests.py []
     env CACHEOPS_LRU=1 ./run_tests.py []
+    env CACHEOPS_USE_LOCK=1 ./run_tests.py []
     env CACHEOPS_DB=postgresql ./run_tests.py []
     ; Djangos pre 1.5 don't work with PostGIS 2.1
     dj{15,16,17,master}: env CACHEOPS_DB=postgis ./run_tests.py []


### PR DESCRIPTION
Hi @Suor,

here is a patch to enable dog-pile avoidance in `cacheops`.

Could you please review it and see if I didn't miss anything ?

This patched version has been running for hours on my 1flow development machine without problems.

I will deploy it on http://1flow.io/ at next major release.

I patched `simple` & `query`, and didn't find any other obvious locations to patch.

Your feedback is appreciated.

Regards,