### PR TITLE
Update() isn't updating the cache at all

### DIFF
--- a/tests/migrations/0002_model141.py
+++ b/tests/migrations/0002_model141.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Model141',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('is_updated', models.BooleanField(default=False)),
+            ],
+        ),
+    ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -216,3 +216,7 @@ if os.environ.get('CACHEOPS_DB') == 'postgis':
 
     class Geometry(gis_models.Model):
         point = gis_models.PointField(geography=True, dim=3, blank=True, null=True, default=None)
+
+# 141
+class Model141(models.Model):
+    is_updated = models.BooleanField()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -480,6 +480,10 @@ class IssueTests(BaseTestCase):
         with self.assertNumQueries(0):
             list(All.objects.cache(ops='all').all())
 
+    def test_141(self):
+        model = Model141.objects.create(is_updated=False)
+        Model141.objects.filter(id=model.id).update(is_updated=True)
+        self.assertEqual(model.is_updated, True)
 
 @unittest.skipUnless(os.environ.get('LONG'), "Too long")
 class LongTests(BaseTestCase):


### PR DESCRIPTION
I'm in the process of converting a big Django johnny-cache project to cacheops. I'm unable to get update() queries to work properly. We use them to avoid running signals for some queries.

I've created a failing test case that shows the bug in action.

Would you mind taking a look and see if this is fixable?