### PR TITLE
Cacheops signals invalidate an object after all other post_save() signals

### DIFF
--- a/tests/migrations/0002_one.py
+++ b/tests/migrations/0002_one.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='One',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('boolean', models.BooleanField(default=False)),
+            ],
+        ),
+    ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -217,3 +217,17 @@ if os.environ.get('CACHEOPS_DB') == 'postgis':
 
     class Geometry(gis_models.Model):
         point = gis_models.PointField(geography=True, dim=3, blank=True, null=True, default=None)
+
+# 145
+class One(models.Model):
+    boolean = models.BooleanField(default=False)
+
+def set_boolean_true(sender, instance, created, **kwargs):
+    if created:
+        return
+
+    dialog = One.objects.cache(ops='all').get(id=instance.id)
+    assert dialog.boolean is True
+
+from django.db.models.signals import post_save
+post_save.connect(set_boolean_true, sender=One)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -481,6 +481,14 @@ class IssueTests(BaseTestCase):
         with self.assertNumQueries(0):
             list(All.objects.cache(ops='all').all())
 
+    def test_145(self):
+        # Create One with boolean False
+        one = One.objects.cache(ops='all').create(boolean=False)
+
+        # Update boolean to True
+        one = One.objects.cache(ops='all').get(id=one.id)
+        one.boolean = True
+        one.save()
 
 @unittest.skipUnless(os.environ.get('LONG'), "Too long")
 class LongTests(BaseTestCase):


### PR DESCRIPTION
Cacheops automatically invalidates instances with a post_save signal. That signal is added after all existing post_save signals. This means that we will get stale data if we do queries inside other signals.

This commit adds a test that does a simple get() query inside a post_save signal, and fails because it only gets access to stale data, not the data that should be saved to the database (this is post_save after all).