### PR TITLE
Fix crash caused by `None` being passed as a model.

### DIFF
--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -109,6 +109,9 @@ def model_profile(model):
     """
     Returns cacheops profile for a model
     """
+    if not model:
+        return None
+
     model_profiles = prepare_profiles()
 
     app = model._meta.app_label


### PR DESCRIPTION
This error [seems to have occurred before](https://github.com/Suor/django-cacheops/issues/82) and may have recently gone into regression.

This change appears to fix the problem for my use case, and the git history implies that this is expected behaviour.