### PR TITLE
Proxy models caching issue

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -816,6 +816,20 @@ class ProxyTests(BaseTestCase):
         with self.assertRaises(NonCachedMedia.DoesNotExist):
             MediaProxy.objects.cache().get(title=media.title)
 
+    def test_proxy_caching(self):
+        video = Video.objects.create(title='Pulp Fiction')
+        self.assertEqual(type(Video.objects.cache().get(pk=video.pk)),
+                         Video)
+        self.assertEqual(type(VideoProxy.objects.cache().get(pk=video.pk)),
+                         VideoProxy)
+
+    def test_proxy_caching_reversed(self):
+        video = Video.objects.create(title='Pulp Fiction')
+        self.assertEqual(type(VideoProxy.objects.cache().get(pk=video.pk)),
+                         VideoProxy)
+        self.assertEqual(type(Video.objects.cache().get(pk=video.pk)),
+                         Video)
+
 
 class MultitableInheritanceTests(BaseTestCase):
     @unittest.expectedFailure


### PR DESCRIPTION
Hi!
Proxy and concrete models have the same cache_key. It's okay, cause they have the same data in db. But if concrete model is cached and you trying to fetch proxy model, you will get concrete model instance anyway. And vise versa: if proxy model is cached, you will get proxy model instance even if you trying to get concrete model.
This is brief example:
```
In [1]: Video.objects.cache().get(pk=1)
Out [1]: <Video: Video object>
In [2]: VideoProxy.objects.cache().get(pk=1)
Out [2]: <Video: Video object>
In [3] VideoProxy.objects.nocache().get(pk=1)
Out [3] <VideoProxy: VideoProxy object>
```
