### PR TITLE
Add support to cache_on_save for multiple field get

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -182,6 +182,14 @@ class Local(models.Model):
 class CacheOnSaveModel(models.Model):
     title = models.CharField(max_length=32)
 
+# uh.
+class CacheOnSaveModelField(models.Model):
+    title = models.CharField(max_length=32)
+    name = models.CharField(max_length=32)
+
+class CacheOnSaveModelFields(models.Model):
+    title = models.CharField(max_length=32)
+    name = models.CharField(max_length=32)
 
 # 47
 class DbAgnostic(models.Model):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -90,6 +90,9 @@ if os.environ.get('CACHEOPS_CONF') == 'old':
     CACHEOPS = {
         'tests.local': ('just_enable', 60*60, {'local_get': True}),
         'tests.cacheonsavemodel': ('just_enable', 60*60, {'cache_on_save': True}),
+        'tests.cacheonsavemodelfield': ('just_enable', 60*60, {'cache_on_save': 'name'}),
+        'tests.cacheonsavemodelfields': ('just_enable', 60*60,
+                                         {'cache_on_save': ['name', 'title']}),
         'tests.dbbinded': ('just_enable', 60*60, {'db_agnostic': False}),
         'tests.genericcontainer': ('all', 60*60),
         'tests.all': ('all', 60*60),
@@ -103,6 +106,8 @@ else:
     CACHEOPS = {
         'tests.local': {'local_get': True},
         'tests.cacheonsavemodel': {'cache_on_save': True},
+        'tests.cacheonsavemodelfield': {'cache_on_save': 'name'},
+        'tests.cacheonsavemodelfields': {'cache_on_save': ['name', 'title']},
         'tests.dbbinded': {'db_agnostic': False},
         'tests.genericcontainer': {'ops': ('fetch', 'get', 'count')},
         'tests.all': {'ops': 'all'},

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -467,6 +467,20 @@ class IssueTests(BaseTestCase):
         with self.assertNumQueries(0):
             CacheOnSaveModel.objects.cache().get(pk=m.pk)
 
+    def test_cache_on_save_single_field_lookup(self):
+        m = CacheOnSaveModelField(title="test", name="trial")
+        m.save()
+
+        with self.assertNumQueries(0):
+            CacheOnSaveModelField.objects.cache().get(name="trial")
+
+    def test_cache_on_save_multiple_field_lookup(self):
+        m = CacheOnSaveModelFields(title="test", name="trial")
+        m.save()
+
+        with self.assertNumQueries(0):
+            CacheOnSaveModelFields.objects.cache().get(title="test", name="trial")
+
     def test_54(self):
         qs = Category.objects.all()
         list(qs) # force load objects to quesryset cache


### PR DESCRIPTION
One of the apps I work on commonly uses a two field lookup so it would be nice to maintain the cache by  these fields as the key. This PR adds that ability but note that I am still in the process of evaluating the change (I am sharing it early to hear your feedback). I also added coverage for the existing cache_on_save option of specifying a single field for the key. 

NB: I elected not to use a dictionary comprehension (dict([(k,v) for...]) vs {k: v for ...} to support older versions of python.