### PR TITLE
Use a local cache during atomic transactions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,8 @@ request will be wrapped in ``transaction.atomic``. Cacheops will not use a local
 to say, not Simple time-invalidated cache or File Cache.
 
 The local cache is thread specific and cleared on commit. Cached items cannot contribute to possible race conditions
-between threads/requests. Data is not cached on rolled back transactions.
+between threads/requests. Data is not cached on rolled back transactions. To maintain current expected behavior, this
+setting is ``False`` by default.
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -118,22 +118,6 @@ There is also a possibility to make all cacheops methods and decorators no-op, e
 
     CACHEOPS_FAKE = True
 
-You can have cacheops use a local memory cache, writing to redis only on commit. This functionality works by patching
-``transaction.atomic`` and ``transaction.Atomic``. When ``ATOMIC_REQUESTS`` is set to ``True`` in ``DATABASES``, every
-request will be wrapped in ``transaction.atomic``. Cacheops will not use a local cache when not in a
-``transaction.atomic`` block, regardless of this setting. This local caching only affects querysets and views, which is
-to say, not Simple time-invalidated cache or File Cache.
-
-The local cache is thread specific and cleared on commit. Cached items cannot contribute to possible race conditions
-between threads. Data is not cached on rolled back transactions. To maintain current expected behavior, this
-setting is ``False`` by default.
-
-Because of the dependency on ``transaction.Atomic``, cacheops ignores this setting unless running django 1.6+.
-
-.. code:: python
-
-    CACHEOPS_RESPECT_ATOMIC = True
-
 Usage
 -----
 
@@ -623,7 +607,7 @@ TODO
 - faster .get() handling for simple cases such as get by pk/id, with simple key calculation
 - integrate with prefetch_related()
 - shard cache between multiple redises
-- add local cache (cleared at the end of request?) (partially implemented by CACHEOPS_RESPECT_ATOMIC)
+- add local cache (cleared at the end of request?) (partially implemented, local cache clearing is currently `django.db.transaction.atomic` based)
 - respect subqueries?
 - respect headers in @cached_view*?
 - group invalidate_obj() calls?

--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,18 @@ There is also a possibility to make all cacheops methods and decorators no-op, e
 
     CACHEOPS_FAKE = True
 
+You can have cacheops use a local memory cache, writing to redis only on commit. This functionality works by patching
+``transaction.atomic`` and ``transaction.Atomic``. When ``ATOMIC_REQUESTS`` is set to ``True`` in ``DATABASES``, every
+request will be wrapped in ``transaction.atomic``. Cacheops will not use a local cache when not in a
+``transaction.atomic`` block, regardless of this setting. This local caching only affects querysets and views, which is
+to say, not Simple time-invalidated cache or File Cache.
+
+The local cache is thread specific and cleared on commit. Cached items cannot contribute to possible race conditions
+between threads/requests. Data is not cached on rolled back transactions.
+
+.. code:: python
+
+    CACHEOPS_RESPECT_ATOMIC = True
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -617,11 +617,10 @@ Here is how you do that. I suppose you have some application code causing it.
 TODO
 ----
 
-- better support transactions
 - faster .get() handling for simple cases such as get by pk/id, with simple key calculation
 - integrate with prefetch_related()
 - shard cache between multiple redises
-- add local cache (cleared at the and of request?)
+- add local cache (cleared at the end of request?) (partially implemented by CACHEOPS_RESPECT_ATOMIC)
 - respect subqueries?
 - respect headers in @cached_view*?
 - group invalidate_obj() calls?

--- a/README.rst
+++ b/README.rst
@@ -125,8 +125,10 @@ request will be wrapped in ``transaction.atomic``. Cacheops will not use a local
 to say, not Simple time-invalidated cache or File Cache.
 
 The local cache is thread specific and cleared on commit. Cached items cannot contribute to possible race conditions
-between threads/requests. Data is not cached on rolled back transactions. To maintain current expected behavior, this
+between threads. Data is not cached on rolled back transactions. To maintain current expected behavior, this
 setting is ``False`` by default.
+
+Because of the dependency on ``transaction.Atomic``, cacheops ignores this setting unless running django 1.6+.
 
 .. code:: python
 

--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
-import warnings
-from cacheops.redis_client import LocalCachedTransactionRedis
 import six
-import redis
-from funcy import memoize, decorator, identity, merge
+from funcy import memoize, merge
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -13,47 +10,10 @@ ALL_OPS = {'get', 'fetch', 'count', 'exists'}
 LRU = getattr(settings, 'CACHEOPS_LRU', False)
 DEGRADE_ON_FAILURE = getattr(settings, 'CACHEOPS_DEGRADE_ON_FAILURE', False)
 
-
-# Support DEGRADE_ON_FAILURE
-if DEGRADE_ON_FAILURE:
-    @decorator
-    def handle_connection_failure(call):
-        try:
-            return call()
-        except redis.ConnectionError as e:
-            warnings.warn("The cacheops cache is unreachable! Error: %s" % e, RuntimeWarning)
-        except redis.TimeoutError as e:
-            warnings.warn("The cacheops cache timed out! Error: %s" % e, RuntimeWarning)
-else:
-    handle_connection_failure = identity
-
-class SafeRedis(LocalCachedTransactionRedis):
-    get = handle_connection_failure(LocalCachedTransactionRedis.get)
-
-
-class LazyRedis(object):
-    def _setup(self):
-        # Connecting to redis
-        try:
-            redis_conf = settings.CACHEOPS_REDIS
-        except AttributeError:
-            raise ImproperlyConfigured('You must specify CACHEOPS_REDIS setting to use cacheops')
-
-        client = (SafeRedis if DEGRADE_ON_FAILURE else LocalCachedTransactionRedis)(**redis_conf)
-
-        object.__setattr__(self, '__class__', client.__class__)
-        object.__setattr__(self, '__dict__', client.__dict__)
-
-    def __getattr__(self, name):
-        self._setup()
-        return getattr(self, name)
-
-    def __setattr__(self, name, value):
-        self._setup()
-        return setattr(self, name, value)
-
-redis_client = LazyRedis()
-
+try:
+    REDIS_CONF = settings.CACHEOPS_REDIS
+except AttributeError:
+    raise ImproperlyConfigured('You must specify CACHEOPS_REDIS setting to use cacheops')
 
 @memoize
 def prepare_profiles():

--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import warnings
-from cacheops.redis import LocalCachedTransactionRedis
+from cacheops.redis_client import LocalCachedTransactionRedis
 import six
 import redis
 from funcy import memoize, decorator, identity, merge

--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import warnings
+from cacheops.redis import LocalCachedTransactionRedis
 import six
 import redis
 from funcy import memoize, decorator, identity, merge
@@ -26,8 +27,8 @@ if DEGRADE_ON_FAILURE:
 else:
     handle_connection_failure = identity
 
-class SafeRedis(redis.StrictRedis):
-    get = handle_connection_failure(redis.StrictRedis.get)
+class SafeRedis(LocalCachedTransactionRedis):
+    get = handle_connection_failure(LocalCachedTransactionRedis.get)
 
 
 class LazyRedis(object):
@@ -38,7 +39,7 @@ class LazyRedis(object):
         except AttributeError:
             raise ImproperlyConfigured('You must specify CACHEOPS_REDIS setting to use cacheops')
 
-        client = (SafeRedis if DEGRADE_ON_FAILURE else redis.StrictRedis)(**redis_conf)
+        client = (SafeRedis if DEGRADE_ON_FAILURE else LocalCachedTransactionRedis)(**redis_conf)
 
         object.__setattr__(self, '__class__', client.__class__)
         object.__setattr__(self, '__dict__', client.__dict__)

--- a/cacheops/invalidation.py
+++ b/cacheops/invalidation.py
@@ -50,7 +50,6 @@ def invalidate_dict(model, obj_dict):
                             for mapping in local_cache.maps:
                                 if key in mapping:
                                     del mapping[key]
-                        break
 
 
 def invalidate_obj(obj):

--- a/cacheops/invalidation.py
+++ b/cacheops/invalidation.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import json
 import threading
 from funcy import memoize, post_processing, ContextDecorator
 from django.db.models.expressions import F

--- a/cacheops/invalidation.py
+++ b/cacheops/invalidation.py
@@ -30,7 +30,7 @@ def invalidate_dict(model, obj_dict):
 
     # is this thing in our local cache?
     try:
-        local_cache = Atomic.thread_local.cache
+        local_cache = Atomic.thread_local.cacheops_transaction_cache
     except AttributeError:
         pass
     else:
@@ -78,7 +78,7 @@ def invalidate_model(model):
 
     # remove the same keys from our local cache, if we are in a transaction
     try:
-        local_cache = Atomic.thread_local.cache
+        local_cache = Atomic.thread_local.cacheops_transaction_cache
     except AttributeError:
         pass
     else:
@@ -98,7 +98,7 @@ def invalidate_all():
     # wipe out our local cache, if we are in a transaction
     try:
         # leave the same amount of dicts as we found, but empty them
-        Atomic.thread_local.cache.maps = [{} for x in Atomic.thread_local.cache.maps]
+        Atomic.thread_local.cacheops_transaction_cache.maps = [{} for x in Atomic.thread_local.cacheops_transaction_cache.maps]
     except AttributeError:
         pass
 

--- a/cacheops/invalidation.py
+++ b/cacheops/invalidation.py
@@ -98,7 +98,9 @@ def invalidate_all():
     # wipe out our local cache, if we are in a transaction
     try:
         # leave the same amount of dicts as we found, but empty them
-        Atomic.thread_local.cacheops_transaction_cache.maps = [{} for x in Atomic.thread_local.cacheops_transaction_cache.maps]
+        Atomic.thread_local.cacheops_transaction_cache.maps = [
+            {} for x in Atomic.thread_local.cacheops_transaction_cache.maps
+        ]
     except AttributeError:
         pass
 

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import sys
-import json
 import threading
 from cacheops import CacheMiss
 import six

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -254,7 +254,7 @@ class QuerySetMixin(object):
             cache_key = self._cache_key()
             if not self._cacheconf['write_only'] and not self._for_write:
                 # Trying get data from cache
-                cache_data = redis_client.get(cache_key)
+                cache_data = redis_client.get(cache_key, local_only=local_only)
                 if cache_data is not None:
                     results = pickle.loads(cache_data)
                     for obj in results:

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -81,6 +81,7 @@ def cached_as(*samples, **kwargs):
             except NotLocal:
                 if local_only:
                     raise
+            except CacheMiss:
                 result = func(*args, **kwargs)
                 redis_client.cache_thing(cache_key, result, cond_dnfs, timeout)
             return result

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -69,6 +69,7 @@ def cache_thing(cache_key, data, cond_dnfs, timeout):
         ]
     )
 
+_marker = object()
 
 def cached_as(*samples, **kwargs):
     """
@@ -117,7 +118,7 @@ def cached_as(*samples, **kwargs):
                     # not in transaction
                     pass
                 else:
-                    if cache_data is not None and cache_data.get('data', None) is not None:
+                    if cache_data is not None and cache_data.get('data', _marker) is not _marker:
                         return cache_data['data']
 
             cache_data = redis_client.get(cache_key)

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -45,8 +45,9 @@ def cache_thing(cache_key, data, cond_dnfs, timeout):
             'data': data,
             'cond_dnfs': cond_dnfs,
             'timeout': timeout,
-            'db_tables': [x for x, y in cond_dnfs],  # help us out later for possible invalidation
-            'cond_dicts': [dict(i) for x, y in cond_dnfs for i in y]  # help us out later for possible invalidation
+            # these two help us out later for possible invalidation
+            'db_tables': [x for x, y in cond_dnfs],
+            'cond_dicts': [dict(i) for x, y in cond_dnfs for i in y]
         }
     except AttributeError:
         # we are not in a transaction.

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -251,7 +251,6 @@ class QuerySetMixin(object):
         cache_this = self._cacheprofile and 'fetch' in self._cacheconf['ops']
         local_only = self._cacheprofile and self._cacheconf.get('local_only', None) or None
 
-
         if cache_this:
             cache_key = self._cache_key()
             if not self._cacheconf['write_only'] and not self._for_write:
@@ -271,7 +270,7 @@ class QuerySetMixin(object):
         if local_only:
             if not cache_key:
                 cache_key = self._cache_key()
-            raise NotLocal('%r: %r' %(self, cache_key))
+            raise NotLocal('%r: %r' % (self, cache_key))
 
         # Cache miss - fallback to overriden implementation
         results = []

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -41,7 +41,7 @@ def cache_thing(cache_key, data, cond_dnfs, timeout):
     """
     try:
         # are we in a transaction?
-        Atomic.thread_local.cache[cache_key] = {
+        Atomic.thread_local.cacheops_transaction_cache[cache_key] = {
             'data': data,
             'cond_dnfs': cond_dnfs,
             'timeout': timeout,
@@ -101,7 +101,7 @@ def cached_as(*samples, **kwargs):
 
             # try transaction local cache first
             try:
-                cache_data = Atomic.thread_local.cache.get(cache_key, None)
+                cache_data = Atomic.thread_local.cacheops_transaction_cache.get(cache_key, None)
             except AttributeError:
                 # not in transaction
                 pass
@@ -287,7 +287,7 @@ class QuerySetMixin(object):
 
                 # try transaction local cache first
                 try:
-                    cache_data = Atomic.thread_local.cache.get(cache_key, None)
+                    cache_data = Atomic.thread_local.cacheops_transaction_cache.get(cache_key, None)
                 except AttributeError:
                     # not in transaction
                     pass

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -278,13 +278,10 @@ class QuerySetMixin(object):
             cache_key = self._cache_key()
             if not self._cacheconf['write_only'] and not self._for_write:
                 # Trying get data from cache
-                results = None
-
                 cache_data = redis_client.get(cache_key)
                 if cache_data is not None:
                     results = pickle.loads(cache_data)
 
-                if results is not None:
                     for obj in results:
                         yield obj
                     raise StopIteration

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
 import threading
-from cacheops import CacheMiss
 import six
 from funcy import select_keys, cached_property, once, once_per, monkey, wraps
 from funcy.py2 import mapcat, map
@@ -76,7 +75,7 @@ def cached_as(*samples, **kwargs):
         def wrapper(*args, **kwargs):
             cache_key = 'as:' + key_func(func, args, kwargs, key_extra)
 
-            cache_data = redis_client.get(cache_key)
+            cache_data = redis_client.get(cache_key, local_only=local_only)
             if cache_data is not None:
                 return pickle.loads(cache_data)
 
@@ -150,7 +149,12 @@ class QuerySetMixin(object):
 
     def _cache_results(self, cache_key, results):
         cond_dnfs = dnfs(self)
-        redis_client.cache_thing(cache_key, pickle.dumps(results, -1), cond_dnfs, self._cacheconf['timeout'])
+        redis_client.cache_thing(
+            cache_key,
+            pickle.dumps(results, -1),
+            cond_dnfs,
+            self._cacheconf['timeout']
+        )
 
     def cache(self, ops=None, timeout=None, write_only=None, local_only=None):
         """

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -1,0 +1,18 @@
+from redis.client import StrictRedis
+from django.db.transaction import Atomic
+import pickle
+
+_marker = object()
+
+class LocalCachedTransactionRedis(StrictRedis):
+    def get(self, name):
+        # try transaction local cache first
+        try:
+            cache_data = Atomic.thread_local.cacheops_transaction_cache.get(name, None)
+        except AttributeError:
+            # not in transaction
+            pass
+        else:
+            if cache_data is not None and cache_data.get('data', _marker) is not _marker:
+                return cache_data['data']
+        return super(LocalCachedTransactionRedis, self).get(name)

--- a/cacheops/redis_client.py
+++ b/cacheops/redis_client.py
@@ -32,10 +32,6 @@ else:
     handle_connection_failure = identity
 
 
-class CacheMiss(Exception):
-    pass
-
-
 class NotLocal(Exception):
     pass
 

--- a/cacheops/redis_client.py
+++ b/cacheops/redis_client.py
@@ -139,7 +139,7 @@ class LocalCachedTransactionRedis(StrictRedis):
             code = STRIP_RE.sub('', code)
         return self.register_script(code)
 
-    def get(self, name):
+    def get(self, name, local_only=None):
         # try transaction local cache first
         try:
             all_contexts = self._local.cacheops_transaction_contexts
@@ -184,6 +184,8 @@ class LocalCachedTransactionRedis(StrictRedis):
                     return cache_item.get('data')
                 except InvalidatedData:
                     pass
+        if local_only:
+            raise CacheMiss
         cache_data = super(LocalCachedTransactionRedis, self).get(name)
         if cache_data is None:
             raise CacheMiss

--- a/cacheops/redis_client.py
+++ b/cacheops/redis_client.py
@@ -1,6 +1,5 @@
 from redis.client import StrictRedis
 from django.db.transaction import Atomic
-import pickle
 
 _marker = object()
 

--- a/cacheops/redis_client.py
+++ b/cacheops/redis_client.py
@@ -261,7 +261,6 @@ class LocalCachedTransactionRedis(StrictRedis):
             for cache_key, value in six.iteritems(context['cache']):
                 self.cache_thing(
                     cache_key,
-                    pre_pickled=True,
                     **{x: y for x, y in six.iteritems(value) if x in (
                         'data',
                         'cond_dnfs',

--- a/cacheops/redis_client.py
+++ b/cacheops/redis_client.py
@@ -219,7 +219,7 @@ class LocalCachedTransactionRedis(StrictRedis):
         else:
             context = find_latest_context_list(contexts)[-1]
             context['cache'][cache_key] = {
-                'data': pickle.dumps(data, -1),
+                'data': data if pre_pickled else pickle.dumps(data, -1),
                 'cond_dnfs': cond_dnfs,
                 'timeout': timeout,
                 # these two help us out later for possible invalidation

--- a/cacheops/redis_client.py
+++ b/cacheops/redis_client.py
@@ -8,11 +8,6 @@ from threading import local
 from funcy import decorator, identity, memoize
 import six
 
-try:
-    from collections import ChainMap
-except ImportError:
-    from chainmap import ChainMap
-
 from redis import ConnectionError, TimeoutError
 from redis.client import StrictRedis
 
@@ -271,11 +266,15 @@ class LocalCachedTransactionRedis(StrictRedis):
                 elif item['type'] == 'all':
                     self.invalidate_all()
             for cache_key, value in six.iteritems(context['cache']):
-                self.cache_thing(cache_key, pre_pickled=True, **{x: y for x, y in six.iteritems(value) if x in (
-                    'data',
-                    'cond_dnfs',
-                    'timeout'
-                )})
+                self.cache_thing(
+                    cache_key,
+                    pre_pickled=True,
+                    **{x: y for x, y in six.iteritems(value) if x in (
+                        'data',
+                        'cond_dnfs',
+                        'timeout'
+                    )}
+                )
 
     def rollback_transaction(self):
         del self._local.cacheops_transaction_contexts
@@ -310,7 +309,6 @@ class LocalCachedTransactionRedis(StrictRedis):
             last_outer_cache.update(inner_context['cache'])
             last_outer_invalidation.extend(inner_context['invalidation'])
             # todo: optimize redundant invalidation
-
 
     def rollback_savepoint(self):
         drop_latest_context(self._local.cacheops_transaction_contexts)
@@ -355,7 +353,6 @@ class LocalCachedTransactionRedis(StrictRedis):
         for key, value in list(cache.items()):
             if db_table in value.get('db_tables', []):
                 cache.pop(key)
-
 
     @handle_connection_failure
     def invalidate_model(self, db_table):

--- a/cacheops/redis_client.py
+++ b/cacheops/redis_client.py
@@ -1,13 +1,60 @@
+import json
+import os.path
+import re
+from threading import local
+
+from funcy import decorator, identity, memoize
+
+try:
+    from collections import ChainMap
+except ImportError:
+    from chainmap import ChainMap
+
+from redis import ConnectionError, TimeoutError
 from redis.client import StrictRedis
-from django.db.transaction import Atomic
+
+from .cross import pickle
+from .conf import LRU, DEGRADE_ON_FAILURE, REDIS_CONF
+import warnings
 
 _marker = object()
 
+STRIP_RE = re.compile(r'TOSTRIP.*/TOSTRIP', re.S)
+
+# Support DEGRADE_ON_FAILURE
+if DEGRADE_ON_FAILURE:
+    @decorator
+    def handle_connection_failure(call):
+        try:
+            return call()
+        except ConnectionError as e:
+            warnings.warn("The cacheops cache is unreachable! Error: %s" % e, RuntimeWarning)
+        except TimeoutError as e:
+            warnings.warn("The cacheops cache timed out! Error: %s" % e, RuntimeWarning)
+else:
+    handle_connection_failure = identity
+
+
 class LocalCachedTransactionRedis(StrictRedis):
+    def __init__(self, *args, **kwargs):
+        super(LocalCachedTransactionRedis, self).__init__(*args, **kwargs)
+        self._local = local()
+
+    @memoize
+    def load_script(self, name, strip=False):
+        """ LUA Script Loader """
+        # TODO: strip comments
+        filename = os.path.join(os.path.dirname(__file__), 'lua/%s.lua' % name)
+        with open(filename) as f:
+            code = f.read()
+        if strip:
+            code = STRIP_RE.sub('', code)
+        return self.register_script(code)
+
     def get(self, name):
         # try transaction local cache first
         try:
-            cache_data = Atomic.thread_local.cacheops_transaction_cache.get(name, None)
+            cache_data = self._local.cacheops_transaction_cache.get(name, None)
         except AttributeError:
             # not in transaction
             pass
@@ -15,3 +62,147 @@ class LocalCachedTransactionRedis(StrictRedis):
             if cache_data is not None and cache_data.get('data', _marker) is not _marker:
                 return cache_data['data']
         return super(LocalCachedTransactionRedis, self).get(name)
+
+    @handle_connection_failure
+    def cache_thing(self, cache_key, data, cond_dnfs, timeout):
+        """
+        Writes data to cache and creates appropriate invalidators.
+        """
+        try:
+            # are we in a transaction?
+            self._local.cacheops_transaction_cache[cache_key] = {
+                'data': pickle.dumps(data, -1),
+                'cond_dnfs': cond_dnfs,
+                'timeout': timeout,
+                # these two help us out later for possible invalidation
+                'db_tables': [x for x, y in cond_dnfs],
+                'cond_dicts': [dict(i) for x, y in cond_dnfs for i in y]
+            }
+            return
+        except AttributeError:
+            # we are not in a transaction.
+            pass
+        self.load_script('cache_thing', LRU)(
+            keys=[cache_key],
+            args=[
+                pickle.dumps(data, -1),
+                json.dumps(cond_dnfs, default=str),
+                timeout
+            ]
+        )
+
+    def start_transaction(self):
+        self._local.cacheops_transaction_cache = ChainMap()
+
+    @handle_connection_failure
+    def commit_transaction(self):
+        for key, value in self._local.cacheops_transaction_cache.items():
+            self.load_script('cache_thing', LRU)(
+                keys=[key],
+                args=[
+                    value['data'],
+                    json.dumps(value['cond_dnfs'], default=str),
+                    value['timeout']
+                ]
+            )
+
+    def end_transaction(self):
+        del self._local.cacheops_transaction_cache
+
+    def start_savepoint(self):
+        self._local.cacheops_transaction_cache.maps.append({})
+
+    def commit_savepoint(self):
+        self._local.cacheops_transaction_cache.maps[1].update(
+            self._local.cacheops_transaction_cache.maps[0]
+        )
+
+    def end_savepoint(self):
+        self._local.cacheops_transaction_cache.maps.pop(0)
+
+    @handle_connection_failure
+    def invalidate_dict(self, db_table, obj_dict):
+        try:
+            local_cache = self._local.cacheops_transaction_cache
+        except AttributeError:
+            # not in a transaction
+            pass
+        else:
+            # is this thing in our local cache?
+            for key, value in local_cache.items():
+                if 'db_tables' in value and 'cond_dicts' in value:
+                    for table, cond_dict in zip(value['db_tables'], value['cond_dicts']):
+                        # is this key for the table we are invalidating?
+                        if table == db_table:
+                            match = False
+                            for obj_key in set(obj_dict.keys()) & set(cond_dict.keys()):
+                                if obj_dict[obj_key] != cond_dict[obj_key]:
+                                    break
+                            else:
+                                match = True
+                            if match or not cond_dict:
+                                # deep delete, to deal with savepoints in the cache
+                                for mapping in local_cache.maps:
+                                    if key in mapping:
+                                        del mapping[key]
+
+        self.load_script('invalidate')(args=[
+            db_table,
+            json.dumps(obj_dict, default=str)
+        ])
+
+    @handle_connection_failure
+    def invalidate_model(self, db_table):
+        try:
+            local_cache = self._local.cacheops_transaction_cache
+        except AttributeError:
+            # we are not in a transaction
+            pass
+        else:
+            # remove the same keys from our local cache
+            for key, value in local_cache.items():
+                if db_table in value.get('db_tables', []):
+                    # deep delete, to deal with savepoints in the cache
+                    for mapping in local_cache.maps:
+                        if key in mapping:
+                            del mapping[key]
+
+        conjs_keys = redis_client.keys('conj:%s:*' % db_table)
+        if conjs_keys:
+            cache_keys = redis_client.sunion(conjs_keys)
+            redis_client.delete(*(list(cache_keys) + conjs_keys))
+
+    @handle_connection_failure
+    def invalidate_all(self):
+        try:
+            local_cache = self._local.cacheops_transaction_cache
+        except AttributeError:
+            # we are not in a transaction
+            pass
+        else:
+            # wipe out our local cache, leaving the same amount of dicts as we found
+            local_cache.maps = [{} for x in local_cache.maps]
+
+        self.flushdb()
+
+class SafeRedis(LocalCachedTransactionRedis):
+    get = handle_connection_failure(LocalCachedTransactionRedis.get)
+
+
+class LazyRedis(object):
+    def _setup(self):
+        # Connecting to redis
+        client = (SafeRedis if DEGRADE_ON_FAILURE else LocalCachedTransactionRedis)(**REDIS_CONF)
+
+        object.__setattr__(self, '__class__', client.__class__)
+        object.__setattr__(self, '__dict__', client.__dict__)
+
+    def __getattr__(self, name):
+        self._setup()
+        return getattr(self, name)
+
+    def __setattr__(self, name, value):
+        self._setup()
+        return setattr(self, name, value)
+
+redis_client = LazyRedis()

--- a/cacheops/redis_client.py
+++ b/cacheops/redis_client.py
@@ -42,6 +42,10 @@ class CacheMiss(Exception):
     pass
 
 
+class NotLocal(Exception):
+    pass
+
+
 def _find_latest_context(contexts):
     if not contexts:
         return contexts
@@ -185,7 +189,7 @@ class LocalCachedTransactionRedis(StrictRedis):
                 except InvalidatedData:
                     pass
         if local_only:
-            raise CacheMiss
+            raise NotLocal(name)
         cache_data = super(LocalCachedTransactionRedis, self).get(name)
         if cache_data is None:
             raise CacheMiss

--- a/cacheops/redis_client.py
+++ b/cacheops/redis_client.py
@@ -70,7 +70,6 @@ class LocalCachedTransactionRedis(StrictRedis):
             raise CacheMiss
         return pickle.loads(cache_data)
 
-
     @handle_connection_failure
     def cache_thing(self, cache_key, data, cond_dnfs, timeout):
         """

--- a/cacheops/redis_client.py
+++ b/cacheops/redis_client.py
@@ -233,10 +233,14 @@ class LocalCachedTransactionRedis(StrictRedis):
         del self._local.cacheops_transaction_contexts
 
         # apply all invalidation to caches previous to them ...
-        for i, context in enumerate(contexts):
+        for context in flatten_contexts(reversed(contexts)):
             for item in context['invalidation']:
-                for previous_context in contexts[i:]:
-                    previous_cache = previous_context['cache']
+                invalidation_contexts = flatten_contexts(contexts)
+                for c in invalidation_contexts:
+                    if context is c:
+                        break
+                for invalidation_context in invalidation_contexts:
+                    previous_cache = invalidation_context['cache']
                     if item['type'] == 'dict':
                         self._local_cache_invalidate_dict(
                             previous_cache, **{x: y for x, y in six.iteritems(item) if x != 'type'}

--- a/cacheops/simple.py
+++ b/cacheops/simple.py
@@ -5,11 +5,15 @@ from .cross import pickle, md5hex
 from django.conf import settings
 from funcy import wraps
 
-from .redis_client import redis_client, handle_connection_failure, CacheMiss
+from .redis_client import redis_client, handle_connection_failure
 from .utils import func_cache_key, cached_view_fab
 
 
 __all__ = ('cache', 'cached', 'cached_view', 'file_cache', 'CacheMiss', 'FileCache', 'RedisCache')
+
+
+class CacheMiss(Exception):
+    pass
 
 
 class CacheKey(str):

--- a/cacheops/simple.py
+++ b/cacheops/simple.py
@@ -5,7 +5,7 @@ from .cross import pickle, md5hex
 from django.conf import settings
 from funcy import wraps
 
-from .conf import redis_client, handle_connection_failure
+from .redis_client import redis_client, handle_connection_failure
 from .utils import func_cache_key, cached_view_fab
 
 
@@ -112,6 +112,7 @@ cached_view = cache.cached_view
 
 FILE_CACHE_DIR = getattr(settings, 'FILE_CACHE_DIR', '/tmp/cacheops_file_cache')
 FILE_CACHE_TIMEOUT = getattr(settings, 'FILE_CACHE_TIMEOUT', 60*60*24*30)
+
 
 class FileCache(BaseCache):
     """

--- a/cacheops/simple.py
+++ b/cacheops/simple.py
@@ -5,15 +5,12 @@ from .cross import pickle, md5hex
 from django.conf import settings
 from funcy import wraps
 
-from .redis_client import redis_client, handle_connection_failure
+from .redis_client import redis_client, handle_connection_failure, CacheMiss
 from .utils import func_cache_key, cached_view_fab
 
 
 __all__ = ('cache', 'cached', 'cached_view', 'file_cache', 'CacheMiss', 'FileCache', 'RedisCache')
 
-
-class CacheMiss(Exception):
-    pass
 
 class CacheKey(str):
     @classmethod
@@ -88,10 +85,8 @@ class RedisCache(BaseCache):
         self.conn = conn
 
     def get(self, cache_key):
-        data = self.conn.get(cache_key)
-        if data is None:
-            raise CacheMiss
-        return pickle.loads(data)
+        # LocalCachedTransactionRedis handles pickle on get.
+        return self.conn.get(cache_key)
 
     @handle_connection_failure
     def set(self, cache_key, data, timeout=None):

--- a/cacheops/simple.py
+++ b/cacheops/simple.py
@@ -85,8 +85,10 @@ class RedisCache(BaseCache):
         self.conn = conn
 
     def get(self, cache_key):
-        # LocalCachedTransactionRedis handles pickle on get.
-        return self.conn.get(cache_key)
+        data = self.conn.get(cache_key)
+        if data is None:
+            raise CacheMiss
+        return pickle.loads(data)
 
     @handle_connection_failure
     def set(self, cache_key, data, timeout=None):

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -1,60 +1,58 @@
-import django
-if django.VERSION >= (1, 6):
-    import json
-    from threading import local
+import json
+from threading import local
 
-    try:
-        from collections import ChainMap
-    except ImportError:
-        from chainmap import ChainMap
+try:
+    from collections import ChainMap
+except ImportError:
+    from chainmap import ChainMap
 
-    from django.conf import settings
-    from django.db import transaction, DEFAULT_DB_ALIAS
+from django.conf import settings
+from django.db import transaction, DEFAULT_DB_ALIAS
 
-    from .conf import LRU
-    from .utils import load_script
-    from .cross import pickle
-    
-    class AtomicMixIn(object):
-        thread_local = local()
+from .conf import LRU
+from .utils import load_script
+from .cross import pickle
 
-        def __enter__(self):
-            if getattr(settings, 'CACHEOPS_RESPECT_ATOMIC', False):
-                connection = transaction.get_connection(self.using)
-                if not connection.in_atomic_block:
-                    # outer most atomic block.
-                    # setup our local cache
-                    AtomicMixIn.thread_local.cacheops_transaction_cache = ChainMap()
-                else:
-                    # new inner atomic block
-                    # add a 'context' to our local cache.
-                    AtomicMixIn.thread_local.cacheops_transaction_cache.maps.append({})
-            self._no_monkey.__enter__()
+class AtomicMixIn(object):
+    thread_local = local()
 
-        def __exit__(self, exc_type, exc_value, traceback):
-            self._no_monkey.__exit__(exc_type, exc_value, traceback)
-            if getattr(settings, 'CACHEOPS_RESPECT_ATOMIC', False):
-                connection = transaction.get_connection(self.using)
-                commit = not connection.closed_in_transaction and\
-                              exc_type is None and\
-                              not connection.needs_rollback
-                if not connection.in_atomic_block:
-                    # exit outer most atomic block.
-                    if commit:
-                        # push the transaction's keys to redis
-                        for key, value in AtomicMixIn.thread_local.cacheops_transaction_cache.items():
-                            load_script('cache_thing', LRU)(
-                                keys=[key],
-                                args=[
-                                    pickle.dumps(value['data'], -1),
-                                    json.dumps(value['cond_dnfs'], default=str),
-                                    value['timeout']
-                                ]
-                            )
-                    del AtomicMixIn.thread_local.cacheops_transaction_cache
-                else:
-                    # exit inner atomic block
-                    context = AtomicMixIn.thread_local.cacheops_transaction_cache.maps.pop(0)
-                    if commit:
-                        # mash the save points context into the outer context.
-                        AtomicMixIn.thread_local.cacheops_transaction_cache.maps[0].update(context)
+    def __enter__(self):
+        if getattr(settings, 'CACHEOPS_RESPECT_ATOMIC', False):
+            connection = transaction.get_connection(self.using)
+            if not connection.in_atomic_block:
+                # outer most atomic block.
+                # setup our local cache
+                AtomicMixIn.thread_local.cacheops_transaction_cache = ChainMap()
+            else:
+                # new inner atomic block
+                # add a 'context' to our local cache.
+                AtomicMixIn.thread_local.cacheops_transaction_cache.maps.append({})
+        self._no_monkey.__enter__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._no_monkey.__exit__(exc_type, exc_value, traceback)
+        if getattr(settings, 'CACHEOPS_RESPECT_ATOMIC', False):
+            connection = transaction.get_connection(self.using)
+            commit = not connection.closed_in_transaction and\
+                          exc_type is None and\
+                          not connection.needs_rollback
+            if not connection.in_atomic_block:
+                # exit outer most atomic block.
+                if commit:
+                    # push the transaction's keys to redis
+                    for key, value in AtomicMixIn.thread_local.cacheops_transaction_cache.items():
+                        load_script('cache_thing', LRU)(
+                            keys=[key],
+                            args=[
+                                pickle.dumps(value['data'], -1),
+                                json.dumps(value['cond_dnfs'], default=str),
+                                value['timeout']
+                            ]
+                        )
+                del AtomicMixIn.thread_local.cacheops_transaction_cache
+            else:
+                # exit inner atomic block
+                context = AtomicMixIn.thread_local.cacheops_transaction_cache.maps.pop(0)
+                if commit:
+                    # mash the save points context into the outer context.
+                    AtomicMixIn.thread_local.cacheops_transaction_cache.maps[0].update(context)

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -8,7 +8,6 @@ if django.VERSION >= (1, 6):
     except ImportError:
         from chainmap import ChainMap
 
-
     from django.conf import settings
     from django.db import transaction, DEFAULT_DB_ALIAS
 
@@ -61,7 +60,6 @@ if django.VERSION >= (1, 6):
                         # mash the save points context into the outer context.
                         Atomic.thread_local.cacheops_transaction_cache.maps[0].update(context)
 
-
     def atomic(using=None, savepoint=True):
         # Bare decorator: @atomic -- although the first argument is called
         # `using`, it's actually the function being decorated.
@@ -70,7 +68,6 @@ if django.VERSION >= (1, 6):
         # Decorator: @atomic(...) or context manager: with atomic(...): ...
         else:
             return Atomic(using, savepoint)
-
 
     transaction.original_atomic = transaction.atomic
     transaction.OriginalAtomic = transaction.Atomic

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -15,7 +15,6 @@ if django.VERSION >= (1, 6):
     from .utils import load_script
     from .cross import pickle
 
-
     class Atomic(transaction.Atomic):
         thread_local = local()
 

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -1,51 +1,27 @@
-import json
+from cacheops.redis_client import redis_client
+from django.db.transaction import get_connection
 
-try:
-    from collections import ChainMap
-except ImportError:
-    from chainmap import ChainMap
-
-from django.db.transaction import Atomic, get_connection
-
-from .conf import LRU
-from .utils import load_script
 
 class AtomicMixIn(object):
     def __enter__(self):
         connection = get_connection(self.using)
         if not connection.in_atomic_block:
-            # outer most atomic block.
-            # setup our local cache
-            Atomic.thread_local.cacheops_transaction_cache = ChainMap()
+            redis_client.start_transaction()
         else:
-            # new inner atomic block
-            # add a 'context' to our local cache.
-            Atomic.thread_local.cacheops_transaction_cache.maps.append({})
+            redis_client.start_savepoint()
         self._no_monkey.__enter__(self)
 
     def __exit__(self, exc_type, exc_value, traceback):
         self._no_monkey.__exit__(self, exc_type, exc_value, traceback)
         connection = get_connection(self.using)
-        commit = not connection.closed_in_transaction and\
-                      exc_type is None and\
+        commit = not connection.closed_in_transaction and \
+                      exc_type is None and \
                       not connection.needs_rollback
         if not connection.in_atomic_block:
-            # exit outer most atomic block.
             if commit:
-                # push the transaction's keys to redis
-                for key, value in Atomic.thread_local.cacheops_transaction_cache.items():
-                    load_script('cache_thing', LRU)(
-                        keys=[key],
-                        args=[
-                            value['data'],
-                            json.dumps(value['cond_dnfs'], default=str),
-                            value['timeout']
-                        ]
-                    )
-            del Atomic.thread_local.cacheops_transaction_cache
+                redis_client.commit_transaction()
+            redis_client.end_transaction()
         else:
-            # exit inner atomic block
-            context = Atomic.thread_local.cacheops_transaction_cache.maps.pop(0)
             if commit:
-                # mash the save points context into the outer context.
-                Atomic.thread_local.cacheops_transaction_cache.maps[0].update(context)
+                redis_client.commit_savepoint()
+            redis_client.end_savepoint()

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -5,7 +5,6 @@ try:
 except ImportError:
     from chainmap import ChainMap
 
-from django.conf import settings
 try:
     from django.db.transaction import Atomic, get_connection
 except ImportError:

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -6,7 +6,12 @@ except ImportError:
     from chainmap import ChainMap
 
 from django.conf import settings
-from django.db.transaction import Atomic, get_connection
+try:
+    from django.db.transaction import Atomic, get_connection
+except ImportError:
+    # django is too old for this.
+    Atomic = None
+    get_connection = None
 
 from .conf import LRU
 from .utils import load_script

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -19,42 +19,40 @@ from .cross import pickle
 
 class AtomicMixIn(object):
     def __enter__(self):
-        if getattr(settings, 'CACHEOPS_RESPECT_ATOMIC', False):
-            connection = get_connection(self.using)
-            if not connection.in_atomic_block:
-                # outer most atomic block.
-                # setup our local cache
-                Atomic.thread_local.cacheops_transaction_cache = ChainMap()
-            else:
-                # new inner atomic block
-                # add a 'context' to our local cache.
-                Atomic.thread_local.cacheops_transaction_cache.maps.append({})
+        connection = get_connection(self.using)
+        if not connection.in_atomic_block:
+            # outer most atomic block.
+            # setup our local cache
+            Atomic.thread_local.cacheops_transaction_cache = ChainMap()
+        else:
+            # new inner atomic block
+            # add a 'context' to our local cache.
+            Atomic.thread_local.cacheops_transaction_cache.maps.append({})
         self._no_monkey.__enter__(self)
 
     def __exit__(self, exc_type, exc_value, traceback):
         self._no_monkey.__exit__(self, exc_type, exc_value, traceback)
-        if getattr(settings, 'CACHEOPS_RESPECT_ATOMIC', False):
-            connection = get_connection(self.using)
-            commit = not connection.closed_in_transaction and\
-                          exc_type is None and\
-                          not connection.needs_rollback
-            if not connection.in_atomic_block:
-                # exit outer most atomic block.
-                if commit:
-                    # push the transaction's keys to redis
-                    for key, value in Atomic.thread_local.cacheops_transaction_cache.items():
-                        load_script('cache_thing', LRU)(
-                            keys=[key],
-                            args=[
-                                pickle.dumps(value['data'], -1),
-                                json.dumps(value['cond_dnfs'], default=str),
-                                value['timeout']
-                            ]
-                        )
-                del Atomic.thread_local.cacheops_transaction_cache
-            else:
-                # exit inner atomic block
-                context = Atomic.thread_local.cacheops_transaction_cache.maps.pop(0)
-                if commit:
-                    # mash the save points context into the outer context.
-                    Atomic.thread_local.cacheops_transaction_cache.maps[0].update(context)
+        connection = get_connection(self.using)
+        commit = not connection.closed_in_transaction and\
+                      exc_type is None and\
+                      not connection.needs_rollback
+        if not connection.in_atomic_block:
+            # exit outer most atomic block.
+            if commit:
+                # push the transaction's keys to redis
+                for key, value in Atomic.thread_local.cacheops_transaction_cache.items():
+                    load_script('cache_thing', LRU)(
+                        keys=[key],
+                        args=[
+                            pickle.dumps(value['data'], -1),
+                            json.dumps(value['cond_dnfs'], default=str),
+                            value['timeout']
+                        ]
+                    )
+            del Atomic.thread_local.cacheops_transaction_cache
+        else:
+            # exit inner atomic block
+            context = Atomic.thread_local.cacheops_transaction_cache.maps.pop(0)
+            if commit:
+                # mash the save points context into the outer context.
+                Atomic.thread_local.cacheops_transaction_cache.maps[0].update(context)

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -38,7 +38,7 @@ class AtomicMixIn(object):
                     load_script('cache_thing', LRU)(
                         keys=[key],
                         args=[
-                            pickle.dumps(value['data'], -1),
+                            value['data'],
                             json.dumps(value['cond_dnfs'], default=str),
                             value['timeout']
                         ]

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -9,7 +9,6 @@ from django.db.transaction import Atomic, get_connection
 
 from .conf import LRU
 from .utils import load_script
-from .cross import pickle
 
 class AtomicMixIn(object):
     def __enter__(self):

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -1,75 +1,77 @@
-import json
-from threading import local
-
-try:
-    from collections import ChainMap
-except ImportError:
-    from chainmap import ChainMap
-
 import django
-from django.conf import settings
-from django.db import transaction, DEFAULT_DB_ALIAS
-
-from .conf import LRU
-from .utils import load_script
-from .cross import pickle
-
-
-class Atomic(transaction.Atomic):
-    thread_local = local()
-
-    def __enter__(self):
-        if getattr(settings, 'CACHEOPS_RESPECT_ATOMIC', False):
-            connection = transaction.get_connection(self.using)
-            if not connection.in_atomic_block:
-                # outer most atomic block.
-                # setup our local cache
-                Atomic.thread_local.cacheops_transaction_cache = ChainMap()
-            else:
-                # new inner atomic block
-                # add a 'context' to our local cache.
-                Atomic.thread_local.cacheops_transaction_cache.maps.append({})
-        super(Atomic, self).__enter__()
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        super(Atomic, self).__exit__(exc_type, exc_value, traceback)
-        if getattr(settings, 'CACHEOPS_RESPECT_ATOMIC', False):
-            connection = transaction.get_connection(self.using)
-            commit = not connection.closed_in_transaction and\
-                          exc_type is None and\
-                          not connection.needs_rollback
-            if not connection.in_atomic_block:
-                # exit outer most atomic block.
-                if commit:
-                    # push the transaction's keys to redis
-                    for key, value in Atomic.thread_local.cacheops_transaction_cache.items():
-                        load_script('cache_thing', LRU)(
-                            keys=[key],
-                            args=[
-                                pickle.dumps(value['data'], -1),
-                                json.dumps(value['cond_dnfs'], default=str),
-                                value['timeout']
-                            ]
-                        )
-                del Atomic.thread_local.cacheops_transaction_cache
-            else:
-                # exit inner atomic block
-                context = Atomic.thread_local.cacheops_transaction_cache.maps.pop(0)
-                if commit:
-                    # mash the save points context into the outer context.
-                    Atomic.thread_local.cacheops_transaction_cache.maps[0].update(context)
-
-
-def atomic(using=None, savepoint=True):
-    # Bare decorator: @atomic -- although the first argument is called
-    # `using`, it's actually the function being decorated.
-    if callable(using):
-        return Atomic(DEFAULT_DB_ALIAS, savepoint)(using)
-    # Decorator: @atomic(...) or context manager: with atomic(...): ...
-    else:
-        return Atomic(using, savepoint)
-
 if django.VERSION >= (1, 6):
+    import json
+    from threading import local
+
+    try:
+        from collections import ChainMap
+    except ImportError:
+        from chainmap import ChainMap
+
+
+    from django.conf import settings
+    from django.db import transaction, DEFAULT_DB_ALIAS
+
+    from .conf import LRU
+    from .utils import load_script
+    from .cross import pickle
+
+
+    class Atomic(transaction.Atomic):
+        thread_local = local()
+
+        def __enter__(self):
+            if getattr(settings, 'CACHEOPS_RESPECT_ATOMIC', False):
+                connection = transaction.get_connection(self.using)
+                if not connection.in_atomic_block:
+                    # outer most atomic block.
+                    # setup our local cache
+                    Atomic.thread_local.cacheops_transaction_cache = ChainMap()
+                else:
+                    # new inner atomic block
+                    # add a 'context' to our local cache.
+                    Atomic.thread_local.cacheops_transaction_cache.maps.append({})
+            super(Atomic, self).__enter__()
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            super(Atomic, self).__exit__(exc_type, exc_value, traceback)
+            if getattr(settings, 'CACHEOPS_RESPECT_ATOMIC', False):
+                connection = transaction.get_connection(self.using)
+                commit = not connection.closed_in_transaction and\
+                              exc_type is None and\
+                              not connection.needs_rollback
+                if not connection.in_atomic_block:
+                    # exit outer most atomic block.
+                    if commit:
+                        # push the transaction's keys to redis
+                        for key, value in Atomic.thread_local.cacheops_transaction_cache.items():
+                            load_script('cache_thing', LRU)(
+                                keys=[key],
+                                args=[
+                                    pickle.dumps(value['data'], -1),
+                                    json.dumps(value['cond_dnfs'], default=str),
+                                    value['timeout']
+                                ]
+                            )
+                    del Atomic.thread_local.cacheops_transaction_cache
+                else:
+                    # exit inner atomic block
+                    context = Atomic.thread_local.cacheops_transaction_cache.maps.pop(0)
+                    if commit:
+                        # mash the save points context into the outer context.
+                        Atomic.thread_local.cacheops_transaction_cache.maps[0].update(context)
+
+
+    def atomic(using=None, savepoint=True):
+        # Bare decorator: @atomic -- although the first argument is called
+        # `using`, it's actually the function being decorated.
+        if callable(using):
+            return Atomic(DEFAULT_DB_ALIAS, savepoint)(using)
+        # Decorator: @atomic(...) or context manager: with atomic(...): ...
+        else:
+            return Atomic(using, savepoint)
+
+
     transaction.original_atomic = transaction.atomic
     transaction.OriginalAtomic = transaction.Atomic
     transaction.atomic = atomic

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -5,12 +5,7 @@ try:
 except ImportError:
     from chainmap import ChainMap
 
-try:
-    from django.db.transaction import Atomic, get_connection
-except ImportError:
-    # django is too old for this.
-    Atomic = None
-    get_connection = None
+from django.db.transaction import Atomic, get_connection
 
 from .conf import LRU
 from .utils import load_script

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -18,7 +18,7 @@ class Atomic(transaction.Atomic):
     thread_local = local()
 
     def __enter__(self):
-        if getattr(settings, 'CACHEOPS_ATOMIC_REQUESTS', False):
+        if getattr(settings, 'CACHEOPS_RESPECT_ATOMIC', False):
             connection = transaction.get_connection(self.using)
             if not connection.in_atomic_block:
                 # outer most atomic block.
@@ -32,7 +32,7 @@ class Atomic(transaction.Atomic):
 
     def __exit__(self, exc_type, exc_value, traceback):
         super(Atomic, self).__exit__(exc_type, exc_value, traceback)
-        if getattr(settings, 'CACHEOPS_ATOMIC_REQUESTS', False):
+        if getattr(settings, 'CACHEOPS_RESPECT_ATOMIC', False):
             connection = transaction.get_connection(self.using)
             commit = not connection.closed_in_transaction and\
                           exc_type is None and\

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -20,8 +20,10 @@ class AtomicMixIn(object):
         if not connection.in_atomic_block:
             if commit:
                 redis_client.commit_transaction()
-            redis_client.end_transaction()
+            else:
+                redis_client.rollback_transaction()
         else:
             if commit:
                 redis_client.commit_savepoint()
-            redis_client.end_savepoint()
+            else:
+                redis_client.rollback_savepoint()

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     from chainmap import ChainMap
 
+import django
 from django.conf import settings
 from django.db import transaction, DEFAULT_DB_ALIAS
 
@@ -68,7 +69,8 @@ def atomic(using=None, savepoint=True):
     else:
         return Atomic(using, savepoint)
 
-transaction.original_atomic = transaction.atomic
-transaction.OriginalAtomic = transaction.Atomic
-transaction.atomic = atomic
-transaction.Atomic = Atomic
+if django.VERSION >= (1, 6):
+    transaction.original_atomic = transaction.atomic
+    transaction.OriginalAtomic = transaction.Atomic
+    transaction.atomic = atomic
+    transaction.Atomic = Atomic

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -11,7 +11,6 @@ from django.db import models
 from django.http import HttpRequest
 
 from .conf import model_profile
-from .redis_client import redis_client
 
 
 # NOTE: we don't serialize this fields since their values could be very long

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -10,7 +10,8 @@ from .cross import md5hex
 from django.db import models
 from django.http import HttpRequest
 
-from .conf import redis_client, model_profile
+from .conf import model_profile
+from .redis_client import redis_client
 
 
 # NOTE: we don't serialize this fields since their values could be very long
@@ -150,23 +151,6 @@ def cached_view_fab(_cached):
             return wrapper
         return decorator
     return cached_view
-
-
-### Lua script loader
-
-import os.path
-
-STRIP_RE = re.compile(r'TOSTRIP.*/TOSTRIP', re.S)
-
-@memoize
-def load_script(name, strip=False):
-    # TODO: strip comments
-    filename = os.path.join(os.path.dirname(__file__), 'lua/%s.lua' % name)
-    with open(filename) as f:
-        code = f.read()
-    if strip:
-        code = STRIP_RE.sub('', code)
-    return redis_client.register_script(code)
 
 
 ### Whitespace handling for template tags

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,7 @@ setup(
         'django>=1.7',
         'redis>=2.9.1',
         'funcy>=1.2,<2.0',
-        'six>=1.4.0',
-        'chainmap>=1.0.2'
+        'six>=1.4.0'
     ],
 
     classifiers=[

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -76,7 +76,7 @@ else:
             # make in memory sqlite test db work with threads for python prior to 3.4
             # see https://code.djangoproject.com/ticket/12118
             'TEST': {
-                'NAME': '/dev/shm/cacheo_sqlite.db'
+                'NAME': '/dev/shm/cacheops_sqlite.db'
             }
         },
         'slave': {
@@ -85,7 +85,7 @@ else:
             # make in memory sqlite test db work with threads for python prior to 3.4
             # see https://code.djangoproject.com/ticket/12118
             'TEST': {
-                'NAME': '/dev/shm/cacheo_sqlite_slave.db'
+                'NAME': '/dev/shm/cacheops_sqlite_slave.db'
             }
         }
     }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -72,11 +72,21 @@ else:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': 'sqlite.db'
+            'NAME': 'sqlite.db',
+            # make in memory sqlite test db work with threads for python prior to 3.4
+            # see https://code.djangoproject.com/ticket/12118
+            'TEST': {
+                'NAME': '/dev/shm/cacheo_sqlite.db'
+            }
         },
         'slave': {
             'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': 'sqlite_slave.db'
+            'NAME': 'sqlite_slave.db',
+            # make in memory sqlite test db work with threads for python prior to 3.4
+            # see https://code.djangoproject.com/ticket/12118
+            'TEST': {
+                'NAME': '/dev/shm/cacheo_sqlite_slave.db'
+            }
         }
     }
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -959,7 +959,7 @@ class IntentionalRollback(RuntimeError):
     pass
 
 
-@unittest.skipUnless(django.VERSION >= (1, 4), "Only for Django 1.4+")
+@unittest.skipUnless(django.VERSION >= (1, 6), "Only for Django 1.6+")
 @override_settings(CACHEOPS_RESPECT_ATOMIC=True)
 class TransactionalLocalCacheTests(TransactionTestCase):
     fixtures = ['basic']
@@ -1030,8 +1030,14 @@ class TransactionalLocalCacheTests(TransactionTestCase):
             uncommitted_remote_cache_results = pickle.loads(uncommitted_remote_cache_results)
         self.assertIsNone(uncommitted_remote_cache_results, msg='Remote cache was populated on rolled back transaction.')
 
+    def test_savepoint_with_commit(self):
+        pass
 
-@unittest.skipUnless(django.VERSION >= (1, 4), "Only for Django 1.4+")
+    def test_savepoint_with_rollback(self):
+        pass
+
+
+@unittest.skipUnless(django.VERSION >= (1, 6), "Only for Django 1.6+")
 @override_settings(CACHEOPS_RESPECT_ATOMIC=True)
 class TransactionalBasicTests(BasicTests):
     pass

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -20,7 +20,8 @@ from cacheops.templatetags.cacheops import register
 decorator_tag = register.decorator_tag
 from .models import *
 
-class BaseTestCase(TestCase):
+
+class BaseTestCase(TransactionTestCase):
     def setUp(self):
         super(BaseTestCase, self).setUp()
         invalidate_all()
@@ -1003,12 +1004,8 @@ def get_category_filter_pk_1_title(queries):
         connection.close()
 
 
-class LocalCachedTransactionTests(TransactionTestCase):
+class LocalCachedTransactionTests(BaseTestCase):
     fixtures = ['basic']
-
-    def setUp(self):
-        super(TransactionTestCase, self).setUp()
-        invalidate_all()
 
     def set_title(self, title):
         new_object = list(Category.objects.filter(pk=1).cache())

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -946,9 +946,8 @@ class IntentionalRollback(RuntimeError):
 
 
 class ThreadWithReturnValue(Thread):
-    def __init__(self, group=None, target=None, name=None,
-                 args=(), kwargs={}, Verbose=None):
-        Thread.__init__(self, group, target, name, args, kwargs, Verbose)
+    def __init__(self, *args, **kwargs):
+        super(ThreadWithReturnValue, self).__init__(*args, **kwargs)
         self._return = None
 
     def run(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,7 +6,7 @@ import unittest
 from threading import Thread
 
 from django.db import connection, connections, DEFAULT_DB_ALIAS
-from django.test import TestCase, TransactionTestCase
+from django.test import TransactionTestCase
 from django.test.client import RequestFactory
 from django.contrib.auth.models import User, Group
 from django.template import Context, Template
@@ -1025,7 +1025,7 @@ class LocalCachedTransactionTests(BaseTestCase):
 
     def assert_not_local_cache(self):
         with self.assertRaises(NotLocal):
-            local_cache_results = list(Category.objects.filter(pk=1).cache(local_only=True))
+            list(Category.objects.filter(pk=1).cache(local_only=True))
 
     def assert_remote_cache_title(self, title, queries=0):
         t = ThreadWithReturnValue(target=get_category_filter_pk_1_title, args=(queries, ))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import pickle
 import re, copy
 import unittest
 from threading import Thread
@@ -10,11 +9,10 @@ from django.test.client import RequestFactory
 from django.contrib.auth.models import User, Group
 from django.template import Context, Template
 from django.db.models import F
-from django.db.transaction import Atomic, atomic
+from django.db.transaction import atomic
 
 from cacheops import invalidate_all, invalidate_model, invalidate_obj, no_invalidation, \
                      cached, cached_view, cached_as, cached_view_as
-from cacheops.conf import redis_client
 from cacheops import invalidate_fragment
 from cacheops.templatetags.cacheops import register
 decorator_tag = register.decorator_tag
@@ -1016,7 +1014,9 @@ class TransactionalLocalCacheTests(TransactionTestCase):
                     'Fjango'
                 )
 
-                t = ThreadWithReturnValue(target=lambda: list(Category.objects.filter(pk=1).cache()))
+                t = ThreadWithReturnValue(
+                    target=lambda: list(Category.objects.filter(pk=1).cache())
+                )
                 t.start()
                 uncommitted_remote_cache_results = t.join()
                 self.assertEqual(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -960,9 +960,17 @@ class ThreadWithReturnValue(Thread):
             if self._Thread__target is not None:
                 self._return = self._Thread__target(*self._Thread__args, **self._Thread__kwargs)
 
-    def join(self):
-        super(ThreadWithReturnValue, self).join()
+    def join(self, *args, **kwargs):
+        super(ThreadWithReturnValue, self).join(*args, **kwargs)
         return self._return
+
+
+def get_category_filter_pk_1():
+    try:
+        return list(Category.objects.filter(pk=1).cache())
+    finally:
+        from django.db import connection
+        connection.close()
 
 
 class TransactionalLocalCacheTests(TransactionTestCase):
@@ -984,7 +992,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
                 'Fjango'
             )
 
-            t = ThreadWithReturnValue(target=lambda: list(Category.objects.filter(pk=1).cache()))
+            t = ThreadWithReturnValue(target=get_category_filter_pk_1)
             t.start()
             uncommitted_remote_cache_results = t.join()
             self.assertEqual(
@@ -998,7 +1006,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
             'Fjango'
         )
 
-        t = ThreadWithReturnValue(target=lambda: list(Category.objects.filter(pk=1).cache()))
+        t = ThreadWithReturnValue(target=get_category_filter_pk_1)
         t.start()
         committed_remote_cache_results = t.join()
         self.assertEqual(
@@ -1020,7 +1028,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
                 )
 
                 t = ThreadWithReturnValue(
-                    target=lambda: list(Category.objects.filter(pk=1).cache())
+                    target=get_category_filter_pk_1
                 )
                 t.start()
                 uncommitted_remote_cache_results = t.join()
@@ -1040,7 +1048,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
             'Django'
         )
 
-        t = ThreadWithReturnValue(target=lambda: list(Category.objects.filter(pk=1).cache()))
+        t = ThreadWithReturnValue(target=get_category_filter_pk_1)
         t.start()
         committed_remote_cache_results = t.join()
         self.assertEqual(
@@ -1063,7 +1071,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
                 )
 
                 t = ThreadWithReturnValue(
-                    target=lambda: list(Category.objects.filter(pk=1).cache())
+                    target=get_category_filter_pk_1
                 )
                 t.start()
                 uncommitted_savepoint_remote_cache_results = t.join()
@@ -1078,7 +1086,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
                 'Fjango'
             )
 
-            t = ThreadWithReturnValue(target=lambda: list(Category.objects.filter(pk=1).cache()))
+            t = ThreadWithReturnValue(target=get_category_filter_pk_1)
             t.start()
             uncommitted_remote_cache_results = t.join()
             self.assertEqual(
@@ -1092,7 +1100,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
             'Fjango'
         )
 
-        t = ThreadWithReturnValue(target=lambda: list(Category.objects.filter(pk=1).cache()))
+        t = ThreadWithReturnValue(target=get_category_filter_pk_1)
         t.start()
         committed_remote_cache_results = t.join()
         self.assertEqual(
@@ -1116,7 +1124,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
                     )
 
                     t = ThreadWithReturnValue(
-                        target=lambda: list(Category.objects.filter(pk=1).cache())
+                        target=get_category_filter_pk_1
                     )
                     t.start()
                     uncommitted_savepoint_remote_cache_results = t.join()
@@ -1135,7 +1143,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
                 'Django'
             )
 
-            t = ThreadWithReturnValue(target=lambda: list(Category.objects.filter(pk=1).cache()))
+            t = ThreadWithReturnValue(target=get_category_filter_pk_1)
             t.start()
             uncommitted_remote_cache_results = t.join()
             self.assertEqual(
@@ -1149,7 +1157,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
             'Django'
         )
 
-        t = ThreadWithReturnValue(target=lambda: list(Category.objects.filter(pk=1).cache()))
+        t = ThreadWithReturnValue(target=get_category_filter_pk_1)
         t.start()
         committed_remote_cache_results = t.join()
         self.assertEqual(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -951,8 +951,14 @@ class ThreadWithReturnValue(Thread):
         self._return = None
 
     def run(self):
-        if self._Thread__target is not None:
-            self._return = self._Thread__target(*self._Thread__args, **self._Thread__kwargs)
+        try:
+            # python 3
+            if self._target is not None:
+                self._return = self._target(*self._args, **self._kwargs)
+        except AttributeError:
+            # python 2
+            if self._Thread__target is not None:
+                self._return = self._Thread__target(*self._Thread__args, **self._Thread__kwargs)
 
     def join(self):
         Thread.join(self)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -969,6 +969,9 @@ def get_category_filter_pk_1():
     try:
         return list(Category.objects.filter(pk=1).cache())
     finally:
+        # django does not drop postgres connections opened due to new threads.
+        # results in Postgres complaining about connected users when django tries to delete test db
+        # https://code.djangoproject.com/ticket/22420#comment:18
         from django.db import connection
         connection.close()
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1189,9 +1189,8 @@ class LocalCachedTransactionTests(TransactionTestCase):
             except IntentionalRollback:
                 pass
             self.assert_remote_cache_title('Django')
-            # failing here can point to broken transactional invalidation handling.
             self.assert_local_cache_title('before')
-        self.assert_remote_cache_title('Django')
+        self.assert_remote_cache_title('before')
         self.assert_local_cache_title('before')
 
     def test_before_nested_atomic_rollback_outer(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1015,7 +1015,8 @@ class LocalCachedTransactionTests(BaseTestCase):
 
     def assert_local_cache_title(self, title):
         try:
-            local_cache_results = list(Category.objects.filter(pk=1).cache(local_only=True))
+            with self.assertNumQueries(0):
+                local_cache_results = list(Category.objects.filter(pk=1).cache(local_only=True))
         except NotLocal:
             self.fail('Not found in local cache.')
         self.assertEqual(
@@ -1025,7 +1026,8 @@ class LocalCachedTransactionTests(BaseTestCase):
 
     def assert_not_local_cache(self):
         with self.assertRaises(NotLocal):
-            list(Category.objects.filter(pk=1).cache(local_only=True))
+            with self.assertNumQueries(0):
+                list(Category.objects.filter(pk=1).cache(local_only=True))
 
     def assert_remote_cache_title(self, title, queries=0):
         t = ThreadWithReturnValue(target=get_category_filter_pk_1_title, args=(queries, ))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1188,7 +1188,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
                         uncommitted_local_cache_results, msg='Local cache was not populated.'
                     )
                     self.assertEqual(
-                        uncommitted_local_cache_results,
+                        uncommitted_local_cache_results['data'],
                         orig_object
                     )
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -953,12 +953,10 @@ class ThreadWithReturnValue(Thread):
         self._return = None
 
     def run(self):
-        try:
-            # python 3
+        if six.PY3:
             if self._target is not None:
                 self._return = self._target(*self._args, **self._kwargs)
-        except AttributeError:
-            # python 2
+        if six.PY2:
             if self._Thread__target is not None:
                 self._return = self._Thread__target(*self._Thread__args, **self._Thread__kwargs)
 
@@ -1037,7 +1035,7 @@ class LocalCachedTransactionTests(TransactionTestCase):
         t.start()
         remote_cache_results = t.join()
         # remote cache results will be None if any exceptions happen in get_category_filter_pk_1
-        if isinstance(remote_cache_results, AssertionError):
+        if isinstance(remote_cache_results, Exception):
             raise remote_cache_results
         self.assertEqual(
             remote_cache_results,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -962,7 +962,6 @@ class IntentionalRollback(RuntimeError):
 
 
 @unittest.skipUnless(django.VERSION >= (1, 6), "Only for Django 1.6+")
-@override_settings(CACHEOPS_RESPECT_ATOMIC=True)
 class TransactionalLocalCacheTests(TransactionTestCase):
     fixtures = ['basic']
 
@@ -1247,9 +1246,3 @@ class TransactionalLocalCacheTests(TransactionTestCase):
             committed_remote_cache_results,
             msg='Remote cache was populated on empty committed transaction.'
         )
-
-
-@unittest.skipUnless(django.VERSION >= (1, 6), "Only for Django 1.6+")
-@override_settings(CACHEOPS_RESPECT_ATOMIC=True)
-class TransactionalBasicTests(BasicTests):
-    pass

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -977,7 +977,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
             cache_key = qs._cache_key()
             uncommitted_local_cache_results = None
             try:
-                uncommitted_local_cache_results = transaction.Atomic.thread_local.cache.get(cache_key, None)
+                uncommitted_local_cache_results = transaction.Atomic.thread_local.cacheops_transaction_cache.get(cache_key, None)
             except AttributeError:
                 pass
             self.assertIsNotNone(uncommitted_local_cache_results, msg='Local cache was not populated.')
@@ -987,7 +987,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
             self.assertIsNone(uncommitted_remote_cache_results, msg='Remote cache populated early.')
         committed_local_cache_results = None
         try:
-            committed_local_cache_results = transaction.Atomic.thread_local.cache.get(cache_key, None)
+            committed_local_cache_results = transaction.Atomic.thread_local.cacheops_transaction_cache.get(cache_key, None)
         except AttributeError:
             pass
         self.assertIsNone(committed_local_cache_results, msg='Local cache was not cleared on committed transaction.')
@@ -1007,7 +1007,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
                 cache_key = qs._cache_key()
                 uncommitted_local_cache_results = None
                 try:
-                    uncommitted_local_cache_results = transaction.Atomic.thread_local.cache.get(cache_key, None)
+                    uncommitted_local_cache_results = transaction.Atomic.thread_local.cacheops_transaction_cache.get(cache_key, None)
                 except AttributeError:
                     pass
                 self.assertIsNotNone(uncommitted_local_cache_results, msg='Local cache was not populated.')
@@ -1021,7 +1021,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
 
         committed_local_cache_results = None
         try:
-            committed_local_cache_results = transaction.Atomic.thread_local.cache.get(cache_key, None)
+            committed_local_cache_results = transaction.Atomic.thread_local.cacheops_transaction_cache.get(cache_key, None)
         except AttributeError:
             pass
         self.assertIsNone(committed_local_cache_results, msg='Local cache was not cleared on rolled back transaction.')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -960,7 +960,7 @@ class IntentionalRollback(RuntimeError):
 
 
 @unittest.skipUnless(django.VERSION >= (1, 4), "Only for Django 1.4+")
-@override_settings(CACHEOPS_ATOMIC_REQUESTS=True)
+@override_settings(CACHEOPS_RESPECT_ATOMIC=True)
 class TransactionalLocalCacheTests(TransactionTestCase):
     fixtures = ['basic']
 
@@ -1032,6 +1032,6 @@ class TransactionalLocalCacheTests(TransactionTestCase):
 
 
 @unittest.skipUnless(django.VERSION >= (1, 4), "Only for Django 1.4+")
-@override_settings(CACHEOPS_ATOMIC_REQUESTS=True)
+@override_settings(CACHEOPS_RESPECT_ATOMIC=True)
 class TransactionalBasicTests(BasicTests):
     pass

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,28 +3,13 @@ import pickle
 import os, re, copy
 import unittest
 
-import django
 from django.db import connection, connections
 from django.test import TestCase, TransactionTestCase
 from django.test.client import RequestFactory
 from django.contrib.auth.models import User, Group
 from django.template import Context, Template
 from django.db.models import F
-try:
-    from django.db.transaction import Atomic, atomic
-except ImportError:
-    # django < 1.6 doesn't have this
-    pass
-try:
-    from django.test.utils import override_settings
-except ImportError:
-    # django < 1.4 doesn't have this
-    class override_settings(object):
-        def __init__(*args, **kwargs):
-            pass
-
-        def __call__(self, fn):
-            return fn
+from django.db.transaction import Atomic, atomic
 
 from cacheops import invalidate_all, invalidate_model, invalidate_obj, no_invalidation, \
                      cached, cached_view, cached_as, cached_view_as
@@ -961,7 +946,6 @@ class IntentionalRollback(RuntimeError):
     pass
 
 
-@unittest.skipUnless(django.VERSION >= (1, 6), "Only for Django 1.6+")
 class TransactionalLocalCacheTests(TransactionTestCase):
     fixtures = ['basic']
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,7 +12,7 @@ from django.template import Context, Template
 from django.db.models import F
 
 try:
-    from django.test import override_settings
+    from django.test.utils import override_settings
 except ImportError:
     # django < 1.4 doesn't have this
     class override_settings(object):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1030,6 +1030,7 @@ class TransactionalLocalCacheTests(TransactionTestCase):
             uncommitted_remote_cache_results = pickle.loads(uncommitted_remote_cache_results)
         self.assertIsNone(uncommitted_remote_cache_results, msg='Remote cache was populated on rolled back transaction.')
 
+
 @unittest.skipUnless(django.VERSION >= (1, 4), "Only for Django 1.4+")
 @override_settings(CACHEOPS_ATOMIC_REQUESTS=True)
 class TransactionalBasicTests(BasicTests):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -9,7 +9,7 @@ from django.test.client import RequestFactory
 from django.contrib.auth.models import User, Group
 from django.template import Context, Template
 from django.db.models import F
-from django.db.transaction import atomic, Atomic
+from django.db.transaction import atomic
 
 from cacheops import invalidate_all, invalidate_model, invalidate_obj, no_invalidation, \
                      cached, cached_view, cached_as, cached_view_as

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -961,7 +961,7 @@ class ThreadWithReturnValue(Thread):
                 self._return = self._Thread__target(*self._Thread__args, **self._Thread__kwargs)
 
     def join(self):
-        Thread.join(self)
+        super(ThreadWithReturnValue, self).join()
         return self._return
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1029,7 +1029,6 @@ class TransactionalLocalCacheTests(TransactionTestCase):
             orig_object
         )
 
-
     def test_transaction_with_rollback(self):
         try:
             with atomic():
@@ -1169,7 +1168,6 @@ class TransactionalLocalCacheTests(TransactionTestCase):
             msg='Remote cache was not populated on committed transaction.'
         )
         self.assertEqual(committed_remote_cache_results, orig_object)
-
 
     def test_savepoint_with_rollback(self):
         with atomic():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -976,44 +976,54 @@ class TransactionalLocalCacheTests(TransactionTestCase):
 
             uncommitted_local_cache_results = None
             try:
-                uncommitted_local_cache_results = transaction.Atomic.thread_local.cacheops_transaction_cache.get(
-                    cache_key, None
-                )
+                uncommitted_local_cache_results =\
+                    transaction.Atomic.thread_local.cacheops_transaction_cache.get(
+                        cache_key, None
+                    )
             except AttributeError:
                 pass
             self.assertIsNotNone(
-                uncommitted_local_cache_results, msg='Local cache was not populated.'
+                uncommitted_local_cache_results,
+                msg='Local cache was not populated.'
             )
             self.assertEqual(
-                uncommitted_local_cache_results['data'], orig_object
+                uncommitted_local_cache_results['data'],
+                orig_object
             )
 
             uncommitted_remote_cache_results = redis_client.get(cache_key)
             if uncommitted_remote_cache_results is not None:
-                results = pickle.loads(uncommitted_remote_cache_results)
+                uncommitted_remote_cache_results = pickle.loads(uncommitted_remote_cache_results)
             self.assertIsNone(
-                uncommitted_remote_cache_results, msg='Remote cache populated early, during transaction.'
+                uncommitted_remote_cache_results,
+                msg='Remote cache populated early, during transaction.'
             )
 
         committed_local_cache_results = None
         try:
-            committed_local_cache_results = transaction.Atomic.thread_local.cacheops_transaction_cache.get(
-                cache_key, None
-            )
+            committed_local_cache_results = \
+                transaction.Atomic.thread_local.cacheops_transaction_cache.get(
+                    cache_key, None
+                )
         except AttributeError:
             pass
         self.assertIsNone(
-            committed_local_cache_results, msg='Local cache was not cleared on committed transaction.'
+            committed_local_cache_results,
+            msg='Local cache was not cleared on committed transaction.'
         )
 
         committed_remote_cache_results = redis_client.get(cache_key)
         if committed_remote_cache_results is not None:
-            committed_remote_cache_results = pickle.loads(committed_remote_cache_results)
+            committed_remote_cache_results = pickle.loads(
+                committed_remote_cache_results
+            )
         self.assertIsNotNone(
-            committed_remote_cache_results, msg='Remote cache was not populated on committed transaction.'
+            committed_remote_cache_results,
+            msg='Remote cache was not populated on committed transaction.'
         )
         self.assertEqual(
-            committed_remote_cache_results, orig_object
+            committed_remote_cache_results,
+            orig_object
         )
 
 
@@ -1026,13 +1036,15 @@ class TransactionalLocalCacheTests(TransactionTestCase):
 
                 uncommitted_local_cache_results = None
                 try:
-                    uncommitted_local_cache_results = transaction.Atomic.thread_local.cacheops_transaction_cache.get(
-                        cache_key, None
-                    )
+                    uncommitted_local_cache_results = \
+                        transaction.Atomic.thread_local.cacheops_transaction_cache.get(
+                            cache_key, None
+                        )
                 except AttributeError:
                     pass
                 self.assertIsNotNone(
-                    uncommitted_local_cache_results, msg='Local cache was not populated.'
+                    uncommitted_local_cache_results,
+                    msg='Local cache was not populated.'
                 )
                 self.assertEqual(
                     uncommitted_local_cache_results['data'], orig_object
@@ -1040,9 +1052,12 @@ class TransactionalLocalCacheTests(TransactionTestCase):
 
                 uncommitted_remote_cache_results = redis_client.get(cache_key)
                 if uncommitted_remote_cache_results is not None:
-                    results = pickle.loads(uncommitted_remote_cache_results)
+                    uncommitted_remote_cache_results = pickle.loads(
+                        uncommitted_remote_cache_results
+                    )
                 self.assertIsNone(
-                    uncommitted_remote_cache_results, msg='Remote cache populated early, during transaction.'
+                    uncommitted_remote_cache_results,
+                    msg='Remote cache populated early, during transaction.'
                 )
 
                 raise IntentionalRollback('test out caches after rolled back transaction.')
@@ -1052,20 +1067,25 @@ class TransactionalLocalCacheTests(TransactionTestCase):
 
         committed_local_cache_results = None
         try:
-            committed_local_cache_results = transaction.Atomic.thread_local.cacheops_transaction_cache.get(
-                cache_key, None
-            )
+            committed_local_cache_results = \
+                transaction.Atomic.thread_local.cacheops_transaction_cache.get(
+                    cache_key, None
+                )
         except AttributeError:
             pass
         self.assertIsNone(
-            committed_local_cache_results, msg='Local cache was not cleared on rolled back transaction.'
+            committed_local_cache_results,
+            msg='Local cache was not cleared on rolled back transaction.'
         )
 
         committed_remote_cache_results = redis_client.get(cache_key)
         if committed_remote_cache_results is not None:
-            committed_remote_cache_results = pickle.loads(committed_remote_cache_results)
+            committed_remote_cache_results = pickle.loads(
+                committed_remote_cache_results
+            )
         self.assertIsNone(
-            committed_remote_cache_results, msg='Remote cache was populated on rolled back transaction.'
+            committed_remote_cache_results,
+            msg='Remote cache was populated on rolled back transaction.'
         )
 
     def test_savepoint_with_commit(self):
@@ -1078,41 +1098,53 @@ class TransactionalLocalCacheTests(TransactionTestCase):
                 uncommitted_savepoint_local_cache_results = None
                 try:
                     uncommitted_savepoint_local_cache_results = \
-                        transaction.Atomic.thread_local.cacheops_transaction_cache.get(cache_key, None)
+                        transaction.Atomic.thread_local.cacheops_transaction_cache.get(
+                            cache_key, None
+                        )
                 except AttributeError:
                     pass
                 self.assertIsNotNone(
-                    uncommitted_savepoint_local_cache_results, msg='Local cache was not populated.'
+                    uncommitted_savepoint_local_cache_results,
+                    msg='Local cache was not populated.'
                 )
                 self.assertEqual(
-                    uncommitted_savepoint_local_cache_results['data'], orig_object
+                    uncommitted_savepoint_local_cache_results['data'],
+                    orig_object
                 )
 
                 uncommitted_savepoint_remote_cache_results = redis_client.get(cache_key)
                 if uncommitted_savepoint_remote_cache_results is not None:
-                    results = pickle.loads(uncommitted_savepoint_remote_cache_results)
+                    uncommitted_savepoint_remote_cache_results = pickle.loads(
+                        uncommitted_savepoint_remote_cache_results
+                    )
                 self.assertIsNone(
-                    uncommitted_savepoint_remote_cache_results, msg='Remote cache populated early, during savepoint.'
+                    uncommitted_savepoint_remote_cache_results,
+                    msg='Remote cache populated early, during savepoint.'
                 )
 
             uncommitted_local_cache_results = None
             try:
                 uncommitted_local_cache_results = \
-                    transaction.Atomic.thread_local.cacheops_transaction_cache.get(cache_key, None)
+                    transaction.Atomic.thread_local.cacheops_transaction_cache.get(
+                        cache_key, None
+                    )
             except AttributeError:
                 pass
             self.assertIsNotNone(
-                uncommitted_local_cache_results, msg='Local cache was cleared on commit savepoint.'
+                uncommitted_local_cache_results,
+                msg='Local cache was cleared on commit savepoint.'
             )
             self.assertEqual(
-                uncommitted_local_cache_results['data'], orig_object
+                uncommitted_local_cache_results['data'],
+                orig_object
             )
 
             uncommitted_remote_cache_results = redis_client.get(cache_key)
             if uncommitted_remote_cache_results is not None:
                 uncommitted_remote_cache_results = pickle.loads(uncommitted_remote_cache_results)
             self.assertIsNone(
-                uncommitted_remote_cache_results, msg='Remote cache was populated early, after savepoint commit.'
+                uncommitted_remote_cache_results,
+                msg='Remote cache was populated early, after savepoint commit.'
             )
 
         committed_local_cache_results = None
@@ -1122,14 +1154,16 @@ class TransactionalLocalCacheTests(TransactionTestCase):
         except AttributeError:
             pass
         self.assertIsNone(
-            committed_local_cache_results, msg='Local cache was not cleared on committed transaction.'
+            committed_local_cache_results,
+            msg='Local cache was not cleared on committed transaction.'
         )
 
         committed_remote_cache_results = redis_client.get(cache_key)
         if committed_remote_cache_results is not None:
             committed_remote_cache_results = pickle.loads(committed_remote_cache_results)
         self.assertIsNotNone(
-            committed_remote_cache_results, msg='Remote cache was not populated on committed transaction.'
+            committed_remote_cache_results,
+            msg='Remote cache was not populated on committed transaction.'
         )
         self.assertEqual(committed_remote_cache_results, orig_object)
 
@@ -1145,16 +1179,24 @@ class TransactionalLocalCacheTests(TransactionTestCase):
                     uncommitted_local_cache_results = None
                     try:
                         uncommitted_local_cache_results = \
-                            transaction.Atomic.thread_local.cacheops_transaction_cache.get(cache_key, None)
+                            transaction.Atomic.thread_local.cacheops_transaction_cache.get(
+                                cache_key, None
+                            )
                     except AttributeError:
                         pass
                     self.assertIsNotNone(
                         uncommitted_local_cache_results, msg='Local cache was not populated.'
                     )
+                    self.assertEqual(
+                        uncommitted_local_cache_results,
+                        orig_object
+                    )
 
                     uncommitted_remote_cache_results = redis_client.get(cache_key)
                     if uncommitted_remote_cache_results is not None:
-                        results = pickle.loads(uncommitted_remote_cache_results)
+                        uncommitted_remote_cache_results = pickle.loads(
+                            uncommitted_remote_cache_results
+                        )
                     self.assertIsNone(
                         uncommitted_remote_cache_results, msg='Remote cache populated early.'
                     )
@@ -1166,38 +1208,44 @@ class TransactionalLocalCacheTests(TransactionTestCase):
 
             committed_local_cache_results = None
             try:
-                committed_local_cache_results = transaction.Atomic.thread_local.cacheops_transaction_cache.get(
-                    cache_key, None
-                )
+                committed_local_cache_results = \
+                    transaction.Atomic.thread_local.cacheops_transaction_cache.get(
+                        cache_key, None
+                    )
             except AttributeError:
                 pass
             self.assertIsNone(
-                committed_local_cache_results, msg='Local cache was not cleared on rolled back savepoint.'
+                committed_local_cache_results,
+                msg='Local cache was not cleared on rolled back savepoint.'
             )
 
             uncommitted_remote_cache_results = redis_client.get(cache_key)
             if uncommitted_remote_cache_results is not None:
                 uncommitted_remote_cache_results = pickle.loads(uncommitted_remote_cache_results)
             self.assertIsNone(
-                uncommitted_remote_cache_results, msg='Remote cache was populated on rolled back savepoint.'
+                uncommitted_remote_cache_results,
+                msg='Remote cache was populated on rolled back savepoint.'
             )
 
         committed_local_cache_results = None
         try:
-            committed_local_cache_results = transaction.Atomic.thread_local.cacheops_transaction_cache.get(
-                cache_key, None
-            )
+            committed_local_cache_results = \
+                transaction.Atomic.thread_local.cacheops_transaction_cache.get(
+                    cache_key, None
+                )
         except AttributeError:
             pass
         self.assertIsNone(
-            committed_local_cache_results, msg='Local cache was not cleared on committed transaction.'
+            committed_local_cache_results,
+            msg='Local cache was not cleared on committed transaction.'
         )
 
         committed_remote_cache_results = redis_client.get(cache_key)
         if committed_remote_cache_results is not None:
             committed_remote_cache_results = pickle.loads(committed_remote_cache_results)
         self.assertIsNone(
-            committed_remote_cache_results, msg='Remote cache was populated on empty committed transaction.'
+            committed_remote_cache_results,
+            msg='Remote cache was populated on empty committed transaction.'
         )
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,7 +10,10 @@ from django.test.client import RequestFactory
 from django.contrib.auth.models import User, Group
 from django.template import Context, Template
 from django.db.models import F
-from django.db import transaction
+try:
+    from django.db import transaction
+except ImportError:
+    pass
 
 try:
     from django.test import override_settings

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,7 +10,11 @@ from django.test.client import RequestFactory
 from django.contrib.auth.models import User, Group
 from django.template import Context, Template
 from django.db.models import F
-
+try:
+    from django.db.transaction import Atomic, atomic
+except ImportError:
+    # django < 1.6 doesn't have this
+    pass
 try:
     from django.test.utils import override_settings
 except ImportError:
@@ -29,11 +33,6 @@ from cacheops import invalidate_fragment
 from cacheops.templatetags.cacheops import register
 decorator_tag = register.decorator_tag
 from .models import *
-try:
-    from cacheops.transaction import Atomic, atomic
-except ImportError:
-    # django version is too old for this.
-    pass
 
 class BaseTestCase(TestCase):
     def setUp(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -973,7 +973,7 @@ def get_category_filter_pk_1():
         connection.close()
 
 
-class TransactionalLocalCacheTests(TransactionTestCase):
+class LocalCachedTransactionTests(TransactionTestCase):
     fixtures = ['basic']
 
     def setUp(self):


### PR DESCRIPTION
In these commits, I've added support to cacheops for django's  `transaction.atomic` context manager. My co-workers and myself have run into situations where rolled back data was making it into the cache. I noticed this was on the readme's todo list, so I hope these changes are something you like for cacheops.

In this new functionality, a thread specific local cache is setup on  `atomic`. Keys that are usually stored in redis are instead held in a local cache . Since `atomic` relates to database transactions, this functionality only affects querysets and views.

When `atomic` commits, it moves local keys to redis and then clears the local cache. When `atomic`  rolls back, it clears the local cache. Inside `atomic` blocks, cacheops will check the local cache before redis. Local cache misses cause cacheops to look to redis as before these changes.

This new functionality also deals with savepoints. Upon entering a nested `atomic` block, a local cache context is setup. When `atomic` commits a savepoint, cacheops moves keys up to the parent's context. This parent can be another save point or the outer transaction. When `atomic` rolls back a savepoint, cacheops will discard the context.

To support these different contexts, the local cache is a [`collections.ChainMap`](https://docs.python.org/3/library/collections.html#chainmap-objects) instance. Python 3.3 introduced `collections.ChainMap`. A [backport is available](https://pypi.python.org/pypi/chainmap) for earlier versions.  I have added this backport as a cacheops package dependency.

I have added a setting for this functionality called `CACHEOPS_RESPECT_ATOMIC`, which defaults to false. Because of the dependency on `transaction.Atomic`, cacheops ignores this setting unless running django 1.6+.

I would like to hear any feedback you have on this pull request. Some of my specific questions are:

* Do you think `CACHEOPS_RESPECT_ATOMIC` should be true by default instead of false?

* My co-workers and myself are not using the Simple time-invalidated cache or File Cache. My understanding that these are not related to database transactions. With this assumption, I did not add transaction local caching code to these functions. Is this correct?

* While developing these changes, I was running the full `run_tests.py` suite. After passing these tests, I moved the functionality behind the  `CACHEOPS_RESPECT_ATOMIC` setting. I wrote some tests of my own, with the `@override_settings` decorator to turn this setting on. I also have the `BasicTests` being rerun with this setting on.

  * Do you think more of the previous tests should be rerun with the new setting on?

  * Would you review the tests I have added? I'm not sure if they can be more simple or organized better.

* Should I rebase the commits in this pull request to a single commit?