### PR TITLE
Post lookup signals to collect information about cache hits and misses

### DIFF
--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -273,8 +273,8 @@ class QuerySetMixin(object):
                     results = pickle.loads(cache_data)
                     for obj in results:
                         # Notify about cache hit
-                        self._send_post_lookup_signal(hit_cache=True)
                         yield obj
+                    self._send_post_lookup_signal(hit_cache=True)
                     raise StopIteration
 
         # Cache miss - fallback to overriden implementation

--- a/cacheops/signals.py
+++ b/cacheops/signals.py
@@ -1,0 +1,3 @@
+import django.dispatch
+
+post_lookup = django.dispatch.Signal(providing_args=["model", "hit_cache"])

--- a/cacheops/signals.py
+++ b/cacheops/signals.py
@@ -1,3 +1,3 @@
 import django.dispatch
 
-post_lookup = django.dispatch.Signal(providing_args=["model", "hit_cache"])
+cache_read = django.dispatch.Signal(providing_args=["func", "hit"])

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@ django>=1.7
 redis>=2.9.1
 funcy>=1.2,<2.0
 six>=1.4.0
+mock>=1.3.0

--- a/tests/models.py
+++ b/tests/models.py
@@ -263,6 +263,10 @@ class M2MWithCharId(models.Model):
     id = models.CharField(max_length=30, primary_key=True)
     name = models.CharField(max_length=30)
 
+# For signals tests
+class SignalTest(models.Model):
+    name = models.CharField(max_length=30)
+
 
 from django.db.models.signals import post_save
 post_save.connect(set_boolean_true, sender=One)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -100,6 +100,7 @@ CACHEOPS = {
     'tests.dbbinded': {'db_agnostic': False},
     'tests.genericcontainer': {'ops': ('fetch', 'get', 'count')},
     'tests.all': {'ops': 'all'},
+    'tests.signaltest': {'ops': 'all'},
     'tests.*': {},
     'tests.noncachedvideoproxy': None,
     'tests.noncachedmedia': None,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -993,10 +993,14 @@ class SignalsTests(BaseTestCase):
     def test_cacheops_signal_post_lookup_with_filter(self, mock_post_lookup_send):
         self.assertFalse(mock_post_lookup_send.called)
 
-        test_model = SignalTest.objects.create(name="foo")
+        # Create some data
+        SignalTest.objects.create(name="foo")
+        SignalTest.objects.create(name="bar")
 
         # Force to evaluate queryset
-        list(SignalTest.objects.filter(id=test_model.id)) # miss
+        list(SignalTest.objects.filter()) # miss
+
+        # make sure we got miss signal only once
         mock_post_lookup_send.assert_called_once_with(
             sender='cacheops.iterator',
             model='tests.models.SignalTest',
@@ -1005,7 +1009,10 @@ class SignalsTests(BaseTestCase):
 
         # Reset mock and try again, this time it should hit cache
         mock_post_lookup_send.reset_mock()
-        list(SignalTest.objects.filter(id=test_model.id)) # hit
+
+        list(SignalTest.objects.filter()) # hit
+
+        # make sure we got hit signal only once
         mock_post_lookup_send.assert_called_once_with(
             sender='cacheops.iterator',
             model='tests.models.SignalTest',
@@ -1014,7 +1021,10 @@ class SignalsTests(BaseTestCase):
 
         # Test that it is called again on every cache hit
         mock_post_lookup_send.reset_mock()
-        list(SignalTest.objects.filter(id=test_model.id)) # hit
+
+        list(SignalTest.objects.filter()) # hit
+
+        # make sure we got miss signal only once
         mock_post_lookup_send.assert_called_once_with(
             sender='cacheops.iterator',
             model='tests.models.SignalTest',

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     djmaster: git+https://github.com/django/django
     mysqlclient
     psycopg2
+    mock
 commands =
     ./run_tests.py []
     env CACHEOPS_LRU=1 ./run_tests.py []


### PR DESCRIPTION
This pull request adds a signal that users can listen to and collect statistics about `django-cacheops` lookup hit rate.

`cache_read` signal is emitted every time `django-cacheops` hits or misses cache when doing `.get(..)` or `.filter(..)` or `@cached_as` decorator makes a cache lookup.

For example if one wanted to collect data about cache hit rates for individual models with `statsd` they could do this in their Django app:

```
from statsd.defaults.django import statsd
from cacheops import signals

def stats_collector(sender, func, hit, **kwargs):
    signal_origin = func.__name__.lower()
    statsd_path = 'cacheops.hit.%s' % signal_origin if hit else 'cacheops.miss.%s' % signal_origin
    statsd.incr(statsd_path)

signals.cache_read.connect(stats_collector)
```

Emitting a signal with no connected listeners shouldn't degrade performance so it would up to the user to decide how they want to process this data. 

Because Django signals are synchronous doing expensive operations in a signal listener would degrade performance.