### PR TITLE
Allow redis connection settings to be specified by a URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,9 @@ Setup redis connection and enable caching for desired models:
         'unix_socket_path': '' # replaces host and port
     }
 
+    # Alternatively the redis connection can be defined using a URL:
+    # CACHEOPS_REDIS = "redis://localhost:6379/1"
+
     CACHEOPS = {
         # Automatically cache any User.objects.get() calls for 15 minutes
         # This includes request.user or post.author access,

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import warnings
+import six
 
 from funcy import decorator, identity, memoize
 import redis
@@ -31,7 +32,11 @@ class LazyRedis(object):
             raise ImproperlyConfigured('You must specify CACHEOPS_REDIS setting to use cacheops')
 
         Redis = SafeRedis if settings.CACHEOPS_DEGRADE_ON_FAILURE else redis.StrictRedis
-        client = Redis(**settings.CACHEOPS_REDIS)
+        # Allow client connection settings to be specified by a URL.
+        if isinstance(settings.CACHEOPS_REDIS, six.string_types):
+            client = Redis.from_url(settings.CACHEOPS_REDIS)
+        else:
+            client = Redis(**settings.CACHEOPS_REDIS)
 
         object.__setattr__(self, '__class__', client.__class__)
         object.__setattr__(self, '__dict__', client.__dict__)


### PR DESCRIPTION
Simple change that allows for the redis connection setttings to be optionally specified using a redis:// url rather than a full dictionary, the url is parsed using `Redis.from_url`.

This is consistent with django-redis, celery.