### PR TITLE
Support for sending the age with the cache_read signal.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -568,7 +568,9 @@ Keeping stats
 -------------
 
 Cacheops provides ``cache_read`` signal for you to keep stats. Signal is emitted immediately after each cache lookup. Passed arguments are: ``sender`` - model class if queryset cache is fetched,
-``func`` - decorated function and ``hit`` - fetch success as boolean value.
+``func`` - decorated function
+``hit`` - fetch success as boolean value.
+``age`` - The age of the object if CACHEOPS_SEND_AGE is True.
 
 Here is simple stats implementation:
 

--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -15,6 +15,7 @@ class Settings(object):
     CACHEOPS = {}
     CACHEOPS_LRU = False
     CACHEOPS_DEGRADE_ON_FAILURE = False
+    CACHEOPS_SEND_AGE = False  # Implies CACHEOPS_DEGRADE_ON_FAILURE
     FILE_CACHE_DIR = '/tmp/cacheops_file_cache'
     FILE_CACHE_TIMEOUT = 60*60*24*30
 

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -51,6 +51,27 @@ def cache_thing(cache_key, data, cond_dnfs, timeout):
     )
 
 
+def get_cache_data(cache_key, timeout, sender=None, func=None):
+
+    if settings.CACHEOPS_SEND_AGE:
+        cache_data, ttl = redis_client.get_with_ttl(cache_key)
+    else:
+        cache_data = redis_client.get(cache_key)
+
+    send_kwargs = dict(
+        sender=sender,
+        func=func,
+        hit=cache_data is not None,
+    )
+
+    if settings.CACHEOPS_SEND_AGE:
+        send_kwargs['age'] = timeout - ttl
+
+    cache_read.send(**send_kwargs)
+
+    return cache_data
+
+
 def cached_as(*samples, **kwargs):
     """
     Caches results of a function and invalidates them same way as given queryset.
@@ -91,9 +112,7 @@ def cached_as(*samples, **kwargs):
                 return func(*args, **kwargs)
 
             cache_key = 'as:' + key_func(func, args, kwargs, key_extra)
-
-            cache_data = redis_client.get(cache_key)
-            cache_read.send(sender=None, func=func, hit=cache_data is not None)
+            cache_data = get_cache_data(cache_key, timeout, func=func)
             if cache_data is not None:
                 return pickle.loads(cache_data)
 
@@ -261,9 +280,8 @@ class QuerySetMixin(object):
 
         cache_key = self._cache_key()
         if not self._cacheconf['write_only'] and not self._for_write:
-            # Trying get data from cache
-            cache_data = redis_client.get(cache_key)
-            cache_read.send(sender=self.model, func=None, hit=cache_data is not None)
+
+            cache_data = get_cache_data(cache_key, model_profile(self.model)['timeout'], sender=self.model)
             if cache_data is not None:
                 return iter(pickle.loads(cache_data))
 

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -281,7 +281,8 @@ class QuerySetMixin(object):
         cache_key = self._cache_key()
         if not self._cacheconf['write_only'] and not self._for_write:
 
-            cache_data = get_cache_data(cache_key, model_profile(self.model)['timeout'], sender=self.model)
+            cache_data = get_cache_data(
+                cache_key, model_profile(self.model)['timeout'], sender=self.model)
             if cache_data is not None:
                 return iter(pickle.loads(cache_data))
 

--- a/cacheops/signals.py
+++ b/cacheops/signals.py
@@ -1,3 +1,3 @@
 import django.dispatch
 
-cache_read = django.dispatch.Signal(providing_args=["func", "hit"])
+cache_read = django.dispatch.Signal(providing_args=["func", "hit", "age"])

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -107,6 +107,7 @@ CACHEOPS = {
 
 CACHEOPS_LRU = bool(os.environ.get('CACHEOPS_LRU'))
 CACHEOPS_DEGRADE_ON_FAILURE = bool(os.environ.get('CACHEOPS_DEGRADE_ON_FAILURE'))
+CACHEOPS_SEND_AGE = bool(os.environ.get('CACHEOPS_SEND_AGE'))
 ALLOWED_HOSTS = ['testserver']
 
 SECRET_KEY = 'abc'


### PR DESCRIPTION
Hi Suor,

This updates the cache_read signal to send the age if the setting CACHEOPS_SEND_AGE is set to True. I made it a setting since adds an additional redis call (ttl) with the get but it should be okay for everyone as the request is pipelined. Using the age we have been able to generate graphs like this using New Relic Insights.

![](http://i.imgur.com/DYTR9xh.png) 
