### PR TITLE
Invalidation Django signals

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -585,8 +585,14 @@ Tags work the same way as corresponding decorators.
 Keeping stats
 -------------
 
-Cacheops provides ``cache_read`` signal for you to keep stats. Signal is emitted immediately after each cache lookup. Passed arguments are: ``sender`` - model class if queryset cache is fetched,
-``func`` - decorated function and ``hit`` - fetch success as boolean value.
+Cacheops provides `Django signals <https://docs.djangoproject.com/en/dev/topics/signals/>`_ for cache lookups and invalidations. You can register signal handlers for them to keep stats. Avoid any heavy operations or actions that would cause infinite recursions.
+
+The following signals are available:
+
+- ``cacheops.signals.cache_read``: Emitted immediately after each cache lookup. Passed arguments are: ``sender`` - model class if queryset cache is fetched, ``func`` - decorated function and ``hit`` - fetch success as boolean value.
+- ``cacheops.signals.invalidation_all``: Emitted immediately after the whole cache is cleared with ``invalidate_all``. Passed arguments are: ``sender`` - ``None``.
+- ``cacheops.signals.invalidation_model``: Emitted immediately after a model is invalidated with ``invalidate_model``. Passed arguments are: ``sender`` - model class being invalidated.
+- ``cacheops.signals.invalidation_obj``: Emitted immediately after a model instance is invalidated with ``invalidate_obj``. Passed arguments are: ``sender`` - model class of the invalidated instance, ``obj`` - the instance of the model being invalidated.
 
 Here is simple stats implementation:
 

--- a/cacheops/signals.py
+++ b/cacheops/signals.py
@@ -1,3 +1,7 @@
 import django.dispatch
 
 cache_read = django.dispatch.Signal(providing_args=["func", "hit"])
+invalidation_all = django.dispatch.Signal(providing_args=[])
+invalidation_model = django.dispatch.Signal(providing_args=[])
+invalidation_obj = django.dispatch.Signal(providing_args=["obj"])
+invalidation_dict = django.dispatch.Signal(providing_args=["obj_dict"])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -15,7 +15,9 @@ from cacheops import invalidate_all, invalidate_model, invalidate_obj, no_invali
 from cacheops import invalidate_fragment
 from cacheops.templatetags.cacheops import register
 from cacheops.transaction import transaction_state
-from cacheops.signals import cache_read
+from cacheops.invalidation import get_obj_dict
+from cacheops.signals import cache_read, invalidation_all, invalidation_model, invalidation_obj, \
+                             invalidation_dict
 
 decorator_tag = register.decorator_tag
 from .models import *
@@ -976,29 +978,41 @@ class GISTests(BaseTestCase):
 
 
 class SignalsTests(BaseTestCase):
+    fixtures = ['basic']
+    maxDiff = None
+
     def setUp(self):
         super(SignalsTests, self).setUp()
 
         def set_signal(signal=None, **kwargs):
-            self.signal_calls.append(kwargs)
+            self.signal_calls.append((signal, kwargs))
 
         self.signal_calls = []
-        cache_read.connect(set_signal, dispatch_uid=1, weak=False)
+        cache_read.connect(set_signal, dispatch_uid='cache_read', weak=False)
+        invalidation_all.connect(set_signal, dispatch_uid='invalidation_all', weak=False)
+        invalidation_model.connect(set_signal, dispatch_uid='invalidation_model', weak=False)
+        invalidation_obj.connect(set_signal, dispatch_uid='invalidation_obj', weak=False)
+        invalidation_dict.connect(set_signal, dispatch_uid='invalidation_dict', weak=False)
 
     def tearDown(self):
+        cache_read.disconnect(dispatch_uid='cache_read')
+        invalidation_all.disconnect(dispatch_uid='invalidation_all')
+        invalidation_model.disconnect(dispatch_uid='invalidation_model')
+        invalidation_obj.disconnect(dispatch_uid='invalidation_obj')
+        invalidation_dict.disconnect(dispatch_uid='invalidation_dict')
         super(SignalsTests, self).tearDown()
-        cache_read.disconnect(dispatch_uid=1)
 
     def test_queryset(self):
         # Miss
         test_model = Category.objects.create(title="foo")
+        self.signal_calls = []
         Category.objects.cache().get(id=test_model.id)
-        self.assertEqual(self.signal_calls, [{'sender': Category, 'func': None, 'hit': False}])
+        self.assertEqual(self.signal_calls, [(cache_read, {'sender': Category, 'func': None, 'hit': False})])
 
         # Hit
         self.signal_calls = []
         Category.objects.cache().get(id=test_model.id) # hit
-        self.assertEqual(self.signal_calls, [{'sender': Category, 'func': None, 'hit': True}])
+        self.assertEqual(self.signal_calls, [(cache_read, {'sender': Category, 'func': None, 'hit': True})])
 
     def test_cached_as(self):
         get_calls = _make_inc(cached_as(Category.objects.filter(title='test')))
@@ -1006,12 +1020,28 @@ class SignalsTests(BaseTestCase):
 
         # Miss
         self.assertEqual(get_calls(), 1)
-        self.assertEqual(self.signal_calls, [{'sender': None, 'func': func, 'hit': False}])
+        self.assertEqual(self.signal_calls, [(cache_read, {'sender': None, 'func': func, 'hit': False})])
 
         # Hit
         self.signal_calls = []
         self.assertEqual(get_calls(), 1)
-        self.assertEqual(self.signal_calls, [{'sender': None, 'func': func, 'hit': True}])
+        self.assertEqual(self.signal_calls, [(cache_read, {'sender': None, 'func': func, 'hit': True})])
+
+    def test_invalidate_all(self):
+        invalidate_all()
+        self.assertEqual(self.signal_calls, [(invalidation_all, {'sender': None})])
+
+    def test_invalidate_model(self):
+        invalidate_model(Post)
+        self.assertEqual(self.signal_calls, [(invalidation_model, {'sender': Post})])
+
+    def test_invalidate_obj(self):
+        post = Post.objects.nocache().get(pk=1)
+        invalidate_obj(post)
+        self.assertEqual(self.signal_calls, [
+            (invalidation_dict, {'sender': Post, 'obj_dict': get_obj_dict(Post, post)}),
+            (invalidation_obj, {'sender': Post, 'obj': post}),
+        ])
 
 
 # Utilities


### PR DESCRIPTION
Hi Suor,

This branch adds four (4) new Django signals for cache invalidation actions, similar to the existing `cache_read` signal:
- `invalidation_all`: the signal is sent from `invalidate_all` call
- `invalidation_model`: the signal is sent from `invalidate_model` call
- `invalidation_obj`: the signal is sent from `invalidate_obj` call
- `invalidation_dict`: the signal is sent from `invalidate_dict` call (undocumented, because the function itself is undocumented.)

We are ourself using these signals for collecting statistics about the number of invalidations, for different models.
