### PR TITLE
Fix late invalidation for djangos on commit hook

### DIFF
--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -66,13 +66,13 @@ class AtomicMixIn(object):
         self._no_monkey.__enter__(self)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self._no_monkey.__exit__(self, exc_type, exc_value, traceback)
         connection = get_connection(self.using)
         if not connection.closed_in_transaction and exc_type is None and \
                 not connection.needs_rollback:
             transaction_state.commit()
         else:
             transaction_state.rollback()
+        self._no_monkey.__exit__(self, exc_type, exc_value, traceback)
 
 
 class CursorWrapperMixin(object):


### PR DESCRIPTION

The `self._no_monkey.__exit__` call triggers possible on commit handlers [1] when inside an transaction. In most of this cases this will get unnoticed because the transaction is marked dirty and the cache is not used anyway. But we triggered a celery worker in an on commit handler and got a race condition where sometimes we got old data since it was fetched before the invalidation.

[1] https://docs.djangoproject.com/en/1.10/topics/db/transactions/#django.db.transaction.on_commit