### PR TITLE
Run on_commit hooks after invalidation

### DIFF
--- a/tests/tests_transactions.py
+++ b/tests/tests_transactions.py
@@ -93,7 +93,8 @@ class TransactionSupportTests(TransactionTestCase):
             with self.assertNumQueries(1):
                 get_category()
 
-    @unittest.skipIf(not hasattr(connection, 'on_commit'), 'that only xx')
+    @unittest.skipIf(not hasattr(connection, 'on_commit'),
+                     'No on commit hooks support (Django < 1.9)')
     def test_call_cacheops_cbs_before_on_commit_cbs(self):
 
         with atomic():

--- a/tests/tests_transactions.py
+++ b/tests/tests_transactions.py
@@ -93,7 +93,6 @@ class TransactionSupportTests(TransactionTestCase):
             with self.assertNumQueries(1):
                 get_category()
 
-
     @unittest.skipIf(not hasattr(connection, 'on_commit'), 'that only xx')
     def test_call_cacheops_cbs_before_on_commit_cbs(self):
 


### PR DESCRIPTION
Ok, I think that one should be good.
We are not changing on_commit behaviour. As I understand it, djangos on_commit hooks are called when a database transaction is commited, but nested Atomics actually leads to the usage of savepoints and not nested transactions. So the behaviour of cacheops on transaction success and djangos on_commit callbacks is different. The only assumption we do now, is that when djangos on_commit hook is called, cacheops transaction_state also needs to be commited.

I actually tried to maintain the `transaction_state` by only patching BaseDatabaseWrapper and that did not work. I think there is information that cacheops needs that can only be seen by the the higher level `Atomic` in a sane way.

It would be nice to also support django-transaction-hooks when used prior to django 1.9

Related https://github.com/Suor/django-cacheops/pull/228 https://github.com/Suor/django-cacheops/pull/229

EDIT:
Tell me if its worth fixing Django 1.7 support