### PR TITLE
Don't presave models by pk if it's not in the cacheops config

### DIFF
--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -29,6 +29,7 @@ from .transaction import transaction_state
 from .signals import cache_read
 
 
+
 __all__ = ('cached_as', 'cached_view_as', 'install_cacheops')
 
 _local_get_cache = {}
@@ -415,6 +416,9 @@ class ManagerMixin(object):
             self._install_cacheops(cls)
 
     def _pre_save(self, sender, instance, **kwargs):
+        profile_model = model_profile(sender)
+        if "all" not in profile_model["ops"] and "get" not in profile_model["ops"]:
+            return
         if instance.pk is not None and not no_invalidation.active:
             try:
                 _old_objs.__dict__[sender, instance.pk] = sender.objects.get(pk=instance.pk)


### PR DESCRIPTION
#237 with this pr, the object that is not in the cacheops config will not be search and presave