### PR TITLE
Distribute package a universal wheel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+UNRELEASED
+- Package is now also distributed as a universal wheel.
+
 4.0.6
 - fixed m2m invalidation issue with certain configs
 - fixed catastrophic backtracking in template extensions
@@ -303,4 +306,3 @@ Backwards incompatible changes:
 
 
 ... lost in ancient history ...
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Wheels are the new standard of Python distribution. As django-cacheops contains no C files, it can be distributed as a universal wheel. Advantages of wheels:

- Faster installation
- Avoids arbitrary code execution for installation by avoiding setup.
- Allows better caching for testing and continuous integration
- Creates .pyc files as part of installation to ensure they match the Python interpreter used
- More consistent installs across platforms and machines.

When you'd normally run `python setup.py sdist upload`, run instead `python setup.py sdist bdist_wheel upload`. For a high level overview of wheels, see:

https://pythonwheels.com/

For even more details, see PEP-427:

https://www.python.org/dev/peps/pep-0427/