### PR TITLE
Use Django bundled six to avoid a dependency

### DIFF
--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-import six
 from funcy import memoize, merge, namespace
 
 from django.conf import settings as base_settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.signals import setting_changed
+from django.utils import six
 from django.utils.module_loading import import_string
 
 

--- a/cacheops/cross.py
+++ b/cacheops/cross.py
@@ -1,4 +1,6 @@
-import six, hashlib
+import hashlib
+
+from django.utils import six
 
 # Use cPickle in python 2 and pickle in python 3
 try:

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -2,12 +2,12 @@
 import sys
 import json
 import threading
-import six
 from funcy import select_keys, cached_property, once, once_per, monkey, wraps, walk, chain
 from funcy.py3 import lmap, map, lcat, join_with
 from .cross import pickle, md5
 
 import django
+from django.utils import six
 from django.utils.encoding import smart_str, force_text
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Manager, Model

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 import warnings
 from contextlib import contextmanager
-import six
 
+from django.utils import six
 from django.core.exceptions import ImproperlyConfigured
 
 from funcy import decorator, identity, memoize, LazyObject

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -2,7 +2,7 @@
 import threading
 from collections import defaultdict
 
-import six
+from django.utils import six
 from django.db import DEFAULT_DB_ALIAS
 from django.db.backends.utils import CursorWrapper
 from django.db.transaction import Atomic, get_connection

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 django>=1.8
 redis>=2.9.1
 funcy>=1.8,<2.0
-six>=1.4.0
 before_after==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'django>=1.8',
         'redis>=2.9.1',
         'funcy>=1.8,<2.0',
-        'six>=1.4.0',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 import sys
-import six
 from threading import Thread
+
+from django.utils import six
 
 
 # Thread utilities


### PR DESCRIPTION
Django ships with a bundled version of six. Can rely on this instead of including six as a separate dependency. Doing so results in one fewer dependency for package users that don't need six.

Django is committed to continued inclusion for backwards compatibility.