### PR TITLE
Make the base Redis client class a setting that defaults to StrictRedis

### DIFF
--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -18,6 +18,7 @@ class Defaults(namespace):
     CACHEOPS = {}
     CACHEOPS_PREFIX = lambda query: ''
     CACHEOPS_LRU = False
+    CACHEOPS_CLIENT_CLASS = None
     CACHEOPS_DEGRADE_ON_FAILURE = False
     CACHEOPS_SENTINEL = {}
 

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 import six
 
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.module_loading import import_string
 
 from funcy import decorator, identity, memoize, LazyObject
 import redis
@@ -26,9 +27,13 @@ else:
 
 LOCK_TIMEOUT = 60
 
+client_class = redis.StrictRedis
+if settings.CACHEOPS_CLIENT_CLASS:
+    client_class = import_string(settings.CACHEOPS_CLIENT_CLASS)
 
-class CacheopsRedis(redis.StrictRedis):
-    get = handle_connection_failure(redis.StrictRedis.get)
+
+class CacheopsRedis(client_class):
+    get = handle_connection_failure(client_class.get)
 
     @contextmanager
     def getting(self, key, lock=False):

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -27,13 +27,9 @@ else:
 
 LOCK_TIMEOUT = 60
 
-client_class = redis.StrictRedis
-if settings.CACHEOPS_CLIENT_CLASS:
-    client_class = import_string(settings.CACHEOPS_CLIENT_CLASS)
 
-
-class CacheopsRedis(client_class):
-    get = handle_connection_failure(client_class.get)
+class CacheopsRedis(redis.StrictRedis):
+    get = handle_connection_failure(redis.StrictRedis.get)
 
     @contextmanager
     def getting(self, key, lock=False):
@@ -89,6 +85,10 @@ def redis_client():
     if settings.CACHEOPS_REDIS and settings.CACHEOPS_SENTINEL:
         raise ImproperlyConfigured("CACHEOPS_REDIS and CACHEOPS_SENTINEL are mutually exclusive")
 
+    client_class = CacheopsRedis
+    if settings.CACHEOPS_CLIENT_CLASS:
+        client_class = import_string(settings.CACHEOPS_CLIENT_CLASS)
+
     if settings.CACHEOPS_SENTINEL:
         if not {'locations', 'service_name'} <= set(settings.CACHEOPS_SENTINEL):
             raise ImproperlyConfigured("Specify locations and service_name for CACHEOPS_SENTINEL")
@@ -96,16 +96,16 @@ def redis_client():
         sentinel = Sentinel(settings.CACHEOPS_SENTINEL['locations'])
         return sentinel.master_for(
             settings.CACHEOPS_SENTINEL['service_name'],
-            redis_class=CacheopsRedis,
+            redis_class=client_class,
             db=settings.CACHEOPS_SENTINEL.get('db', 0),
             socket_timeout=settings.CACHEOPS_SENTINEL.get('socket_timeout')
         )
 
     # Allow client connection settings to be specified by a URL.
     if isinstance(settings.CACHEOPS_REDIS, six.string_types):
-        return CacheopsRedis.from_url(settings.CACHEOPS_REDIS)
+        return client_class.from_url(settings.CACHEOPS_REDIS)
     else:
-        return CacheopsRedis(**settings.CACHEOPS_REDIS)
+        return client_class(**settings.CACHEOPS_REDIS)
 
 
 ### Lua script loader


### PR DESCRIPTION
We've been maintaining a fork of cacheops for some time which has fallen farther and farther behind your releases – if we could pass in the base Redis class we could keep most of our customizations in our Django application codebase, and it'd be much easier to keep cacheops up to date.

**This change adds a `CACHEOPS_CLIENT_CLASS` setting that can be used to pass a class name to import and use instead of `redis.StrictRedis`.** Generally I expect this will be a subclass of `StrictRedis` with some customizations or enhancements, but it could be any class with the same interface.