### PR TITLE
Fix #292 : Give using parameter to invalidation functions

### DIFF
--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -441,7 +441,7 @@ class ManagerMixin(object):
 
         # Invoke invalidations for both old and new versions of saved object
         old = _old_objs.__dict__.pop((sender, instance.pk), None)
-        using = kwargs.get('using', DEFAULT_DB_ALIAS)
+        using = kwargs['using']
         if old:
             invalidate_obj(old, using=using)
         invalidate_obj(instance, using=using)
@@ -487,8 +487,7 @@ class ManagerMixin(object):
         """
         # NOTE: this will behave wrong if someone changed object fields
         #       before deletion (why anyone will do that?)
-        using = kwargs.get('using', DEFAULT_DB_ALIAS)
-        invalidate_obj(instance, using=using)
+        invalidate_obj(instance, using=kwargs['using'])
 
     def inplace(self):
         return self.get_queryset().inplace()
@@ -527,7 +526,7 @@ def invalidate_m2m(sender=None, instance=None, model=None, action=None, pk_set=N
         instance_column, model_column = model_column, instance_column
 
     # TODO: optimize several invalidate_objs/dicts at once
-    using = kwargs.get('using', DEFAULT_DB_ALIAS)
+    using = kwargs['using']
     if action == 'pre_clear':
         objects = sender.objects.filter(**{instance_column: instance.pk})
         for obj in objects:

--- a/tests/models.py
+++ b/tests/models.py
@@ -193,8 +193,7 @@ class DbAgnostic(models.Model):
     pass
 
 class DbBinded(models.Model):
-    pass
-
+    name = models.CharField(max_length=32, default='')
 
 # contrib.postgis
 if os.environ.get('CACHEOPS_DB') == 'postgis':

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -96,7 +96,7 @@ CACHEOPS_DEFAULTS = {
 CACHEOPS = {
     'tests.local': {'local_get': True},
     'tests.cacheonsavemodel': {'cache_on_save': True},
-    'tests.dbbinded': {'ops': 'count', 'db_agnostic': False},
+    'tests.dbbinded': {'db_agnostic': False},
     'tests.*': {},
     'tests.noncachedvideoproxy': None,
     'tests.noncachedmedia': None,

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -96,7 +96,7 @@ CACHEOPS_DEFAULTS = {
 CACHEOPS = {
     'tests.local': {'local_get': True},
     'tests.cacheonsavemodel': {'cache_on_save': True},
-    'tests.dbbinded': {'db_agnostic': False},
+    'tests.dbbinded': {'ops': 'count', 'db_agnostic': False},
     'tests.*': {},
     'tests.noncachedvideoproxy': None,
     'tests.noncachedmedia': None,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -976,3 +976,15 @@ class MultiDBInvalidationTests(BaseTestCase):
         category = Category.objects.using('slave').create(title='update')
         category.delete(using='slave')
         mock_invalidate_dict.assert_called_with(mock.ANY, mock.ANY, using='slave')
+
+    @mock.patch('cacheops.invalidation.invalidate_dict')
+    def test_m2m_changed_call_invalidate(self, mock_invalidate_dict):
+        label = Label.objects.create()
+        brand = Brand.objects.create()
+        brand.labels.add(label)
+        mock_invalidate_dict.assert_called_with(mock.ANY, mock.ANY, using=DEFAULT_DB_ALIAS)
+
+        label = Label.objects.using('slave').create()
+        brand = Brand.objects.using('slave').create()
+        brand.labels.add(label)
+        mock_invalidate_dict.assert_called_with(mock.ANY, mock.ANY, using='slave')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -910,7 +910,7 @@ class MultiDBInvalidationTests(BaseTestCase):
             DbBinded.objects.cache().using('slave').count()
 
     @mock.patch('cacheops.invalidation.invalidate_dict')
-    def test_bulk_update_call_invalidate(self, mock_invalidate_dict):
+    def test_bulk_create_call_invalidate(self, mock_invalidate_dict):
         category = Category(title='bulk')
         Category.objects.bulk_create([category])
         mock_invalidate_dict.assert_called_with(mock.ANY, mock.ANY, using=DEFAULT_DB_ALIAS)


### PR DESCRIPTION
#292 
Give using argument to the invalidation functions call in query.py (invalidate_obj, invalidate_dict). 
I did not modify invalidate_* call in management. Not sure it is needed to do something in this file. 