### PR TITLE
Fix test database to work in environments without /dev/shm

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -75,7 +75,7 @@ else:
             # Make in memory sqlite test db to work with threads
             # See https://code.djangoproject.com/ticket/12118
             'TEST': {
-                'NAME': '/dev/shm/cacheops_sqlite.db'
+                'NAME': ':memory:cache=shared'
             }
         },
         'slave': {


### PR DESCRIPTION
Running the tests failed for me on MacOS without this change. I verified that the tests now work for me on MacOS with both Python 2.7 and Python 3.7.