### PR TITLE
Add option to @cached_as to prevent caching on concurrent invalidation

### DIFF
--- a/cacheops/lua/cache_thing.lua
+++ b/cacheops/lua/cache_thing.lua
@@ -1,9 +1,15 @@
 local prefix = KEYS[1]
 local key = KEYS[2]
+local precall_key = KEYS[3]
 local data = ARGV[1]
 local dnfs = cjson.decode(ARGV[2])
 local timeout = tonumber(ARGV[3])
 
+if precall_key ~= '' and not redis.call('get', precall_key) then
+  -- Cached data was invalidated during the function call. The data is
+  -- stale and should not be cached.
+  return
+end
 
 -- Write data to cache
 redis.call('setex', key, timeout, data)

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -123,7 +123,8 @@ def cached_as(*samples, **kwargs):
                     # the key to prevent falsely thinking the key was not
                     # invalidated when in fact it was invalidated and the
                     # function was called again in another process.
-                    precall_key = prefix + 'asp:' + key_func(func, args, kwargs, key_extra + [random()])
+                    suffix = key_func(func, args, kwargs, key_extra + [random()])
+                    precall_key = prefix + 'asp:' + suffix
                     for retry_count in range(max_retry_count):
                         # Retry calling the function until we get a valid
                         # result.

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -22,7 +22,7 @@ from .utils import monkey_mix, stamp_fields, func_cache_key, cached_view_fab, fa
 from .sharding import get_prefix
 from .redis import redis_client, handle_connection_failure, load_script
 from .tree import dnfs
-from .invalidation import invalidate_obj, invalidate_dict, no_invalidation, invalidate_keys
+from .invalidation import invalidate_obj, invalidate_dict, no_invalidation
 from .transaction import transaction_states
 from .signals import cache_read
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -262,7 +262,7 @@ class DecoratorTests(BaseTestCase):
         p.save()                               # invalidate by Post
         self.assertEqual(get_calls(1), 3)      # miss and cache
 
-    def test_cached_as_retries_if_invalidated_during_func(self):
+    def test_cached_as_not_cached_if_invalidated_during_func(self):
         c = Category.objects.create(title='test')
         get_calls = make_invalidate_and_inc(cached_as(c, keep_fresh=True), c, 1)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from cacheops import invalidate_all
+from cacheops import invalidate_all, invalidate_obj
 from cacheops.transaction import transaction_states
 
 
@@ -29,6 +29,20 @@ def make_inc(deco=lambda x: x):
 
     inc.get = lambda: calls[0]
     return inc
+
+
+def make_invalidate_and_inc(deco, obj, invalidation_count):
+    calls = [0]
+
+    @deco
+    def invalidate_and_inc(_=None, **kw):
+        if calls[0] < invalidation_count:
+            invalidate_obj(obj)
+        calls[0] += 1
+        return calls[0]
+
+    invalidate_and_inc.get = lambda: calls[0]
+    return invalidate_and_inc
 
 
 # Thread utilities


### PR DESCRIPTION
This change allows us to ensure that a @cached_as function always returns valid results and that stale data is not cached. Without this change, there are at least two possible race conditions:

### Case 1: Caching stale data

Consider a function `get_book_names()` decorated with `@cached_as(Book.objects.all())`. This function executes the queryset `Book.objects.all()` to return an array of book names. The cache needs to be invalidated if any book changes.

1. Process 1 calls `get_book_names()`. Its return value is not yet cached so Process 1 begins evaluating the function `get_book_names()` and executes the query to get all books.
2. Process 2 modifies an book `b` and changes its name from "Stale" to "New" and saves it.
3. All cache keys that depend on `b` are invalidated.
4. Process 1 finishes evaluating `get_book_names()`. This list of book names still has the name "Stale" for book `b`. This list is now cached.
5. Calling `get_book_names()` again returns the cached value with stale data.

In this case, the stale data should not be cached so that future requests will get the correct book names. It would be even better if this function call returned the new book names.

### Case 2: Returning inconsistent data

Consider a function `get_book_author_names()` decorated with `@cached_as(Book, Author)`. This function executes the queryset to return an array of books and their authors. The cache needs to be invalidated if any book or author changes.

1. Process 1 calls `get_book_author_names()`. Its return value is not yet cached so Process 1 begins evaluating the function `get_book_author_names()` and executes the query to get all books. Process 1 iterates through each book and for each book executes a separate query to get its author. Suppose there are 10 books by author "Sue". Process 1 iterates through the first five books by Sue to get the book and author names.
2. Process 2 modifies the author "Sue" and changes her name from "Sue" to "Susan" and saves it.
3. All cache keys that depend on Sue are invalidated.
4. Process 1 iterates through the remaining five books by Sue. These books now have author name "Susan". The resulting list of books now has five books by Sue and five by Susan, which is inconsistent.

This problem could be fixed by getting all books and authors in a single SQL query or by wrapping the entire call in a transaction, but the fix for Case 1 also addresses Case 2.

### The fix

We would like to enforce the invariant that if the samples that the function depends on are invalidated, that the function's return value is also invalid. To enforce this condition, we add an boolean option `retry_until_valid` to `@cached_as` that does the following:
* Before calling the function, we store a precache key unique to this function invocation that will get invalidated whenever the samples are invalidated.
* Before returning a value, check to see if the precache key is still present. If not, store the precache key again and retry calling the function.
* After caching the result, check to see if the precache key is still present. If not, invalidate the cached result and retry calling the function.

Note that if your function does any internal caching, this will need to be reset when the function is invoked to prevent stale data from persisting across retries. (e.g. call `copy.deepcopy()` on QuerySets to clear the result cache).

I added a `max_retry_count` parameter to help prevent infinite loops. I decided to raise an exception when the retry count is reached to ensure that invalid data is never returned. If it is acceptable to stale data you could change this behavior.

#### Automated tests
I added two automated tests:
1. `test_cached_as_retries_if_invalidated_during_func`
2. `test_cached_as_raises_exception_if_too_many_retries`

#### Manual tests
I verified the cases above in my web application with multiple worker processes.