### PR TITLE
Pass connection options through CACHEOPS_SENTINEL

### DIFF
--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -95,7 +95,7 @@ def redis_client():
 
         sentinel = Sentinel(
             settings.CACHEOPS_SENTINEL['locations'],
-            omit(settings.CACHEOPS_SENTINEL, ('locations', 'service_name', 'db')))
+            **omit(settings.CACHEOPS_SENTINEL, ('locations', 'service_name', 'db')))
         return sentinel.master_for(
             settings.CACHEOPS_SENTINEL['service_name'],
             redis_class=client_class,

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -6,7 +6,7 @@ import six
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
-from funcy import decorator, identity, memoize, LazyObject
+from funcy import decorator, identity, memoize, omit, LazyObject
 import redis
 from redis.sentinel import Sentinel
 from .conf import settings
@@ -93,10 +93,9 @@ def redis_client():
         if not {'locations', 'service_name'} <= set(settings.CACHEOPS_SENTINEL):
             raise ImproperlyConfigured("Specify locations and service_name for CACHEOPS_SENTINEL")
 
-        sentinel = Sentinel(settings.CACHEOPS_SENTINEL['locations'], **{
-            k: v for k, v in settings.CACHEOPS_SENTINEL.items()
-            if k not in ('locations', 'service_name', 'db')
-        })
+        sentinel = Sentinel(
+            settings.CACHEOPS_SENTINEL['locations'],
+            omit(settings.CACHEOPS_SENTINEL, ('locations', 'service_name', 'db')))
         return sentinel.master_for(
             settings.CACHEOPS_SENTINEL['service_name'],
             redis_class=client_class,

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -93,12 +93,14 @@ def redis_client():
         if not {'locations', 'service_name'} <= set(settings.CACHEOPS_SENTINEL):
             raise ImproperlyConfigured("Specify locations and service_name for CACHEOPS_SENTINEL")
 
-        sentinel = Sentinel(settings.CACHEOPS_SENTINEL['locations'])
+        sentinel = Sentinel(settings.CACHEOPS_SENTINEL['locations'], **{
+            k: v for k, v in settings.CACHEOPS_SENTINEL.items()
+            if k not in ('locations', 'service_name', 'db')
+        })
         return sentinel.master_for(
             settings.CACHEOPS_SENTINEL['service_name'],
             redis_class=client_class,
-            db=settings.CACHEOPS_SENTINEL.get('db', 0),
-            socket_timeout=settings.CACHEOPS_SENTINEL.get('socket_timeout')
+            db=settings.CACHEOPS_SENTINEL.get('db', 0)
         )
 
     # Allow client connection settings to be specified by a URL.


### PR DESCRIPTION
fixes #286 This changes make possible to define socket timeouts both for Sentinel and Redis connections, as well as any other extra configuration accepted by the connection pool.