### PR TITLE
Django 2.2 bulk_create ignore_conflicts support

### DIFF
--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -373,8 +373,8 @@ class QuerySetMixin(object):
         else:
             return self._no_monkey.exists(self)
 
-    def bulk_create(self, objs, batch_size=None):
-        objs = self._no_monkey.bulk_create(self, objs, batch_size=batch_size)
+    def bulk_create(self, objs, *args, **kwargs):
+        objs = self._no_monkey.bulk_create(self, objs, *args, **kwargs)
         if family_has_profile(self.model):
             for obj in objs:
                 invalidate_obj(obj, using=self.db)


### PR DESCRIPTION
There is new argument in django QuerySet bulk_create method called ignore_conflicts which breaks cacheops patched querysets / managers.