### PR TITLE
Custom managers

### DIFF
--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -5,7 +5,6 @@ import threading
 import six
 from random import random
 
-from django.db.models.manager import BaseManager
 from funcy import select_keys, cached_property, once, once_per, monkey, wraps, walk, chain
 from funcy.py3 import lmap, map, lcat, join_with
 from .cross import pickle, md5
@@ -15,6 +14,7 @@ from django.utils.encoding import smart_str, force_text
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DEFAULT_DB_ALIAS
 from django.db.models import Model
+from django.db.models.manager import BaseManager
 from django.db.models.query import QuerySet
 from django.db.models.sql.datastructures import EmptyResultSet
 from django.db.models.signals import pre_save, post_save, post_delete, m2m_changed

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -4,6 +4,8 @@ import json
 import threading
 import six
 from random import random
+
+from django.db.models.manager import BaseManager
 from funcy import select_keys, cached_property, once, once_per, monkey, wraps, walk, chain
 from funcy.py3 import lmap, map, lcat, join_with
 from .cross import pickle, md5
@@ -12,7 +14,7 @@ import django
 from django.utils.encoding import smart_str, force_text
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DEFAULT_DB_ALIAS
-from django.db.models import Manager, Model
+from django.db.models import Model
 from django.db.models.query import QuerySet
 from django.db.models.sql.datastructures import EmptyResultSet
 from django.db.models.signals import pre_save, post_save, post_delete, m2m_changed
@@ -579,7 +581,7 @@ def install_cacheops():
     """
     Installs cacheops by numerous monkey patches
     """
-    monkey_mix(Manager, ManagerMixin)
+    monkey_mix(BaseManager, ManagerMixin)
     monkey_mix(QuerySet, QuerySetMixin)
 
     # Use app registry to introspect used apps
@@ -588,7 +590,7 @@ def install_cacheops():
     # Install profile and signal handlers for any earlier created models
     for model in apps.get_models(include_auto_created=True):
         if family_has_profile(model):
-            if not isinstance(model._default_manager, Manager):
+            if not isinstance(model._default_manager, BaseManager):
                 raise ImproperlyConfigured("Can't install cacheops for %s.%s model:"
                                            " non-django model class or manager is used."
                                             % (model._meta.app_label, model._meta.model_name))

--- a/tests/models.py
+++ b/tests/models.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, time
 
 from django.db import models
 from django.db.models.query import QuerySet
-from django.db.models import sql
+from django.db.models import sql, manager
 from django.contrib.auth.models import User
 
 
@@ -223,3 +223,17 @@ post_save.connect(set_boolean_true, sender=One)
 class Device(models.Model):
     uid = models.UUIDField(default=uuid.uuid4)
     model = models.CharField(max_length=64)
+
+
+# 333
+class CustomeQuerySet(QuerySet):
+    pass
+
+
+class CustomFromQSManager(manager.BaseManager.from_queryset(CustomeQuerySet)):
+    use_for_related_fields = True
+
+
+class CustomFromQSModel(models.Model):
+    boolean = models.BooleanField(default=False)
+    objects = CustomFromQSManager()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -9,7 +9,6 @@ from django.db import connection
 from django.db import DEFAULT_DB_ALIAS
 from django.test import override_settings
 from django.test.client import RequestFactory
-from django.contrib.auth.models import User
 from django.template import Context, Template
 from django.db.models import F, Count, Sum
 # These were added in Django 2.0
@@ -606,6 +605,12 @@ class IssueTests(BaseTestCase):
 
     def test_316(self):
         Category.objects.cache().annotate(num=Count('posts')).aggregate(total=Sum('num'))
+
+    def test_333(self):
+        # ensure that we can use a manager not derived from Manger
+        # (i.e. using manager.BaseManager.from_queryset)
+        mgr = CustomFromQSModel.objects
+        assert isinstance(mgr, CustomFromQSManager)
 
 
 class RelatedTests(BaseTestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -606,12 +606,6 @@ class IssueTests(BaseTestCase):
     def test_316(self):
         Category.objects.cache().annotate(num=Count('posts')).aggregate(total=Sum('num'))
 
-    def test_333(self):
-        # ensure that we can use a manager not derived from Manger
-        # (i.e. using manager.BaseManager.from_queryset)
-        mgr = CustomFromQSModel.objects
-        assert isinstance(mgr, CustomFromQSManager)
-
 
 class RelatedTests(BaseTestCase):
     fixtures = ['basic']


### PR DESCRIPTION
Fixes #333 for custom managers

Updated check for manager to support custom managers
Added tests
Added exception handling around importing custom managers

This was https://github.com/Suor/django-cacheops/pull/334

Needed to make this a branch so I could keep master in step with suor:master