### PR TITLE
Fix stamp_fields utility function

### DIFF
--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -65,7 +65,7 @@ def stamp_fields(model):
     Returns serialized description of model fields.
     """
     stamp = str(sorted(
-        (f.name, f.attname, f.db_column, f.__class__.__name__)
+        (f.name, f.attname, f.db_column or '', f.__class__.__name__)
         for f in model._meta.fields))
     return md5hex(stamp)
 

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -65,7 +65,7 @@ def stamp_fields(model):
     Returns serialized description of model fields.
     """
     stamp = str(sorted(
-        (f.name, f.attname, f.db_column or '', f.__class__.__name__)
+        json.dumps(f.deconstruct(), sort_keys=True, default=obj_key)
         for f in model._meta.fields))
     return md5hex(stamp)
 

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -64,7 +64,9 @@ def stamp_fields(model):
     """
     Returns serialized description of model fields.
     """
-    stamp = str(sorted((f.name, f.attname, f.db_column, f.__class__) for f in model._meta.fields))
+    stamp = str(sorted(
+        (f.name, f.attname, f.db_column, f.__class__.__name__)
+        for f in model._meta.fields))
     return md5hex(stamp)
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -226,14 +226,31 @@ class Device(models.Model):
 
 
 # 333
-class CustomeQuerySet(QuerySet):
+class CustomQuerySet(QuerySet):
     pass
 
 
-class CustomFromQSManager(manager.BaseManager.from_queryset(CustomeQuerySet)):
+class CustomFromQSManager(manager.BaseManager.from_queryset(CustomQuerySet)):
     use_for_related_fields = True
 
 
 class CustomFromQSModel(models.Model):
     boolean = models.BooleanField(default=False)
     objects = CustomFromQSManager()
+
+
+# 352
+class CombinedField(models.CharField):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.another_field = models.CharField(*args, **kwargs)
+
+    def contribute_to_class(self, cls, name, **kwargs):
+        super().contribute_to_class(cls, name, private_only=True)
+
+        self.another_field.contribute_to_class(cls, name, **kwargs)
+
+
+class CombinedFieldModel(models.Model):
+    text = CombinedField(max_length=8, default='example')

--- a/tests/models.py
+++ b/tests/models.py
@@ -243,12 +243,10 @@ class CustomFromQSModel(models.Model):
 class CombinedField(models.CharField):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
         self.another_field = models.CharField(*args, **kwargs)
 
     def contribute_to_class(self, cls, name, **kwargs):
         super().contribute_to_class(cls, name, private_only=True)
-
         self.another_field.contribute_to_class(cls, name, **kwargs)
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -593,6 +593,10 @@ class IssueTests(BaseTestCase):
     def test_316(self):
         Category.objects.cache().annotate(num=Count('posts')).aggregate(total=Sum('num'))
 
+    def test_352(self):
+        CombinedFieldModel.objects.create()
+        list(CombinedFieldModel.objects.cache().all())
+
 
 class RelatedTests(BaseTestCase):
     fixtures = ['basic']


### PR DESCRIPTION
In `stamp_fields` utility function we create a stamp from the list of `(f.name, f.attname, f.db_column, f.__class__)` for all model fields returned from meta:

```python
stamp = str(sorted((f.name, f.attname, f.db_column, f.__class__) for f in model._meta.fields))
```

The last element is the actual class type of the field and not a class name. This will fail, as before being stringified the list is sorted, and the classes cannot be compared. We should use a class name instead.

Also, if `db_column` was not provided in model definition, `f.db_column` will be `None`, which is not comparable as well.

Practically, a model may have two fields with the same name and `attname` if one field was contributed to model as private. `model._meta.fields` return both local and private fields.