### PR TITLE
Extend dnfs() to catch subqueries used for annotation

### DIFF
--- a/cacheops/tree.py
+++ b/cacheops/tree.py
@@ -129,7 +129,9 @@ def dnfs(qs):
     # Add any subqueries used for annotation
     if qs.query.annotations:
         subqueries = (
-            query_dnf(q.query) for q in qs.query.annotations.values() if type(q) is Subquery
+            # Django 3.0+ sets Subquery.query
+            query_dnf(getattr(q, 'query', q.queryset.query)) for q in qs.query.annotations.values()
+            if type(q) is Subquery
         )
         dnfs_.update(join_with(lcat, subqueries))
 


### PR DESCRIPTION
Closes #365: Support invalidation for annotation subqueries

Extends `dnfs()` to check for subqueries used within `annotate()` on a queryset and, if present, attach them to the DNF tree. This is my first foray into the inner workings of cacheops, so feedback is much appreciated!