### PR TITLE
Adds prefix to all keys.  Adds ignore_prefix kwarg.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -650,7 +650,20 @@ A ``query`` object passed to callback also enables reflection on used databases 
         if query.tables == ['blog_post']:
             return 'blog:'
 
-**NOTE:** prefix is not used in simple and file cache. This might change in future cacheops.
+**NOTE:** Prefix is now used on all cacheops operations.  This was not the case for simple and file cache in cacheops versions 5.1 and earlier.  To share cache between multiple applciations, cache can be saved without the prefix by including ``ignore_prefix=True`` to any of the decorators:
+
+.. code:: python
+
+    from cacheops import cached, cached_view
+
+    @cached(timeout=number_of_seconds, ignore_prefix=True)
+    def top_articles(category):
+        return ... # Some costly queries
+
+    @cached_view(timeout=number_of_seconds, ignore_prefix=True)
+    def top_articles(request, category=None):
+        # Some costly queries
+        return HttpResponse(...)
 
 
 Using memory limit

--- a/README.rst
+++ b/README.rst
@@ -650,7 +650,7 @@ A ``query`` object passed to callback also enables reflection on used databases 
         if query.tables == ['blog_post']:
             return 'blog:'
 
-**NOTE:** Prefix is now used on all cacheops operations.  This was not the case for simple and file cache in cacheops versions 5.1 and earlier.  To share cache between multiple applciations, cache can be saved without the prefix by including ``ignore_prefix=True`` to any of the decorators:
+**NOTE:** Prefix is now used on all cacheops operations except ``file_cache``.   This was not the case in cacheops versions 5.1 and earlier.  To share cache between multiple applications, the prefix can be ignored by including the keyword argument ``ignore_prefix=True`` to any of the decorators:
 
 .. code:: python
 

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -60,7 +60,7 @@ def cache_thing(prefix, cache_key, data, cond_dnfs, timeout, dbs=(), precall_key
 
 
 def cached_as(*samples, timeout=None, extra=None, lock=None, keep_fresh=False,
-                        key_func=func_cache_key):
+                        key_func=func_cache_key, ignore_prefix=False):
     """
     Caches results of a function and invalidates them same way as given queryset(s).
     NOTE: Ignores queryset cached ops settings, always caches.

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -13,6 +13,7 @@ def get_concrete_model(model):
     return next((b for b in model.__mro__ if issubclass(b, models.Model) and b is not models.Model
                  and not b._meta.proxy and not b._meta.abstract), None)
 
+
 def model_family(model):
     """
     Returns a list of all proxy models, including subclasess, superclassses and siblings.
@@ -34,6 +35,7 @@ def family_has_profile(cls):
 
 class MonkeyProxy(object):
     pass
+
 
 def monkey_mix(cls, mixin):
     """
@@ -86,12 +88,14 @@ def obj_key(obj):
     else:
         return str(obj)
 
+
 def func_cache_key(func, args, kwargs, extra=None):
     """
     Calculate cache key based on func and arguments
     """
     factors = [func, args, kwargs, extra]
     return md5hex(json.dumps(factors, sort_keys=True, default=obj_key))
+
 
 def view_cache_key(func, args, kwargs, extra=None):
     """
@@ -103,6 +107,7 @@ def view_cache_key(func, args, kwargs, extra=None):
     else:
         uri = args[0]
     return 'v:' + func_cache_key(func, args[1:], kwargs, extra=(uri, extra))
+
 
 def cached_view_fab(_cached):
     def force_render(response):
@@ -139,6 +144,7 @@ from django.utils.safestring import mark_safe
 
 NEWLINE_BETWEEN_TAGS = mark_safe('>\n<')
 SPACE_BETWEEN_TAGS = mark_safe('> <')
+
 
 def carefully_strip_whitespace(text):
     def repl(m):


### PR DESCRIPTION
Resolves #325 

Adds the prefix to all decorators, and simple caching methods.  As this plugs a giant potential security issue where cache can leak between different deployments and applications, namespacing all keys is critical and should be the default behavior.  I've included the ability to revert to the previous key names by adding the parameter `ignore_prefix` to the decorators and simple cache methods.  This allows cache to be shared by eliminating the prefix, but only if the user explicitly requests it.  