### PR TITLE
Fix inconsistency of `transaction_states`

### DIFF
--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -77,7 +77,7 @@ class AtomicMixIn(object):
             self._no_monkey.__exit__(self, exc_type, exc_value, traceback)
         except DatabaseError:
             transaction_states[self.using].rollback()
-        finally:
+        else:
             if not connection.closed_in_transaction and exc_type is None and \
                     not connection.needs_rollback:
                 if transaction_states[self.using]:

--- a/cacheops/transaction.py
+++ b/cacheops/transaction.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 from funcy import once, decorator
 
-from django.db import DEFAULT_DB_ALIAS
+from django.db import DEFAULT_DB_ALIAS, DatabaseError
 from django.db.backends.utils import CursorWrapper
 from django.db.transaction import Atomic, get_connection, on_commit
 
@@ -73,13 +73,17 @@ class AtomicMixIn(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         connection = get_connection(self.using)
-        self._no_monkey.__exit__(self, exc_type, exc_value, traceback)
-        if not connection.closed_in_transaction and exc_type is None and \
-                not connection.needs_rollback:
-            if transaction_states[self.using]:
-                transaction_states[self.using].commit()
-        else:
+        try:
+            self._no_monkey.__exit__(self, exc_type, exc_value, traceback)
+        except DatabaseError:
             transaction_states[self.using].rollback()
+        finally:
+            if not connection.closed_in_transaction and exc_type is None and \
+                    not connection.needs_rollback:
+                if transaction_states[self.using]:
+                    transaction_states[self.using].commit()
+            else:
+                transaction_states[self.using].rollback()
 
 
 class CursorWrapperMixin(object):

--- a/tests/tests_transactions.py
+++ b/tests/tests_transactions.py
@@ -1,10 +1,10 @@
-from django.db import connection
+from django.db import connection, IntegrityError
 from django.db.transaction import atomic
 from django.test import TransactionTestCase
 
 from cacheops.transaction import queue_when_in_transaction
 
-from .models import Category
+from .models import Category, Post
 from .utils import run_in_thread
 
 
@@ -90,6 +90,22 @@ class TransactionSupportTests(TransactionTestCase):
             get_category()
             with self.assertNumQueries(1):
                 get_category()
+
+    def test_rollback_during_integrity_error(self):
+        # store category in cache
+        get_category()
+
+        # Make current DB be "dirty" by write
+        try:
+            with atomic():
+                Post.objects.create(category_id=-1, title='')
+        except (IntegrityError, Exception):
+            # however, this write should be rolled back and current DB should
+            # not be "dirty"
+            pass
+
+        with self.assertNumQueries(0):
+            get_category()
 
     def test_call_cacheops_cbs_before_on_commit_cbs(self):
         calls = []

--- a/tests/tests_transactions.py
+++ b/tests/tests_transactions.py
@@ -99,7 +99,7 @@ class TransactionSupportTests(TransactionTestCase):
         try:
             with atomic():
                 Post.objects.create(category_id=-1, title='')
-        except (IntegrityError, Exception):
+        except IntegrityError:
             # however, this write should be rolled back and current DB should
             # not be "dirty"
             pass


### PR DESCRIPTION
Original case was:
- Django with `ATOMIC_REQUESTS` enabled
- Cache stopped work randomly on random `uwsgi` workers (while other continued to use/invalidate cache)
- Cache started to work after restarting worker
    
The problem was that neither `TransactionState.commit`, nor `TransactionState.rollback` code was called after `IntegrityError`, so `transaction_states` kept one not handled `TransactionState` and marked all other requests as `dirty` and didn't use cache.