### PR TITLE
Add cluster support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build
 sqlite*.db
 .tox
 .cache
+.idea
+.vscode
+.DS_Store

--- a/README.rst
+++ b/README.rst
@@ -662,6 +662,21 @@ A ``query`` object passed to callback also enables reflection on used databases 
 **NOTE:** prefix is not used in simple and file cache. This might change in future cacheops.
 
 
+Cluster mode
+----------------------
+
+In order to enable cluster mode
+
+.. code:: python
+
+    CACHEOPS_CLUSTER_ENABLED = True
+
+In this mode, the prefix function will attached with a Redis Hashtag validation. Therefore, if your prefix contains a syntax of Redis' Hashtag, it will throw an error
+
+.. code:: python
+    CACHEOPS_PREFIX = lambda query: '{prefix}' # not ok, since {prefix} is a redis hashtag
+    CACHEOPS_PREFIX = lambda query: '[prefix]' # ok
+
 Custom serialization
 --------------------
 

--- a/cacheops/__init__.py
+++ b/cacheops/__init__.py
@@ -6,7 +6,7 @@ from django.apps import AppConfig
 
 from .simple import *
 from .query import *
-from .invalidation import *
+from .invalidator import *
 from .templatetags.cacheops import *
 from .transaction import install_cacheops_transaction_support
 

--- a/cacheops/cluster/__init__.py
+++ b/cacheops/cluster/__init__.py
@@ -1,0 +1,3 @@
+from .invalidation import *
+from .cache_thing import *
+from .prefix_validator import *

--- a/cacheops/cluster/cache_thing.py
+++ b/cacheops/cluster/cache_thing.py
@@ -1,0 +1,80 @@
+"""
+Implementation of cache thing lua script to distribute the key across clusters
+"""
+
+from cacheops.redis import redis_client
+
+from cacheops.cluster.key_crafter import craft_scheme_key, craft_invalidator_key
+
+# A pair of funcs
+# NOTE: we depend here on keys order being stable
+def conj_schema(conj: dict) -> str:
+    """
+    create a field list that used by filter to save in the scheme keys
+    for example: ModelA.objects.filter(x=1, y=2) -> return "x,y"
+
+    the conj object contain field:value pair used by filter function
+    """
+    field_list = conj.keys() if conj else []
+    parts = [str(field) for field in field_list]
+
+    return ','.join(parts)
+
+
+def cache_thing(keys, args, strip=False):
+    """
+    The cache_thing script is smart enough to store enough information
+    so that we can craft the invalidator keys from invalidation flow
+
+    Since we have enough information to craft invalidation keys, schemes key.
+    We don't have to put all these keys in 1 node
+
+    -> Move the Lua script content to python so that we can distribute the key to multiple node
+    """
+    prefix, key = keys
+    precall_key, data, query_info, timeout = args
+
+    if precall_key != '' and redis_client.exists(precall_key) == 0:
+        # Cached data was invalidated during the function call. The data is
+        # stale and should not be cached.
+        return
+
+    # Update schemes and invalidators
+    for db_table, query_set in query_info.items():
+        for conj in query_set:
+            # Ensure scheme is known
+            redis_client.sadd(
+                craft_scheme_key(prefix, db_table),
+                conj_schema(conj),
+            )
+
+            # Add new cache_key to list of dependencies
+            # craft_invalidator_key is the better name for conj_cache_key
+            conj_key = craft_invalidator_key(prefix, db_table, conj)
+            redis_client.sadd(conj_key, key)
+            # NOTE: an invalidator should live longer than any key it references.
+            #       So we update its ttl on every key if needed.
+            # NOTE: if CACHEOPS_LRU is True when invalidators should be left persistent,
+            #       so we strip next section from this script.
+
+            if strip:
+                continue
+
+            conj_ttl = redis_client.ttl(conj_key)
+            if conj_ttl < timeout:
+                # We set conj_key life with a margin over key life to call expire rarer
+                # And add few extra seconds to be extra safe
+                redis_client.expire(conj_key, timeout * 2 + 10)
+
+    # Write data to cache
+    # this should be here because if we unable to set invalidator key for current data key,
+    # we will have the outdated value
+    # -> no one want to have an outdated value
+    # but by write the data to cache after the invalidator key stuff
+    # if we are unable to set the data -> we will have another change next time
+    # also, in the invalidation process, deleting non-exist key is an accepted behaviour by redis
+    has_lock = redis_client.get(key) == b'LOCK'
+    if has_lock:
+        redis_client.setex(key, timeout, data)
+    else:
+        redis_client.set(key, data, ex=timeout, nx=True)

--- a/cacheops/cluster/invalidation.py
+++ b/cacheops/cluster/invalidation.py
@@ -1,0 +1,224 @@
+import threading
+import re
+from funcy import memoize, post_processing, ContextDecorator, decorator
+from django.db import DEFAULT_DB_ALIAS
+from django.db.models.expressions import F, Expression
+
+from cacheops.conf import settings
+from cacheops.sharding import get_prefix
+from cacheops.redis import redis_client, handle_connection_failure
+from cacheops.signals import cache_invalidated
+from cacheops.transaction import queue_when_in_transaction
+
+from cacheops.cluster.key_crafter import craft_scheme_key, craft_invalidator_key
+
+
+__all__ = ('invalidate_obj', 'invalidate_model', 'invalidate_all', 'no_invalidation')
+
+
+@decorator
+def skip_on_no_invalidation(call):
+    if not settings.CACHEOPS_ENABLED or no_invalidation.active:
+        return
+
+    if not settings.CACHEOPS_CLUSTER_ENABLED:
+        return
+
+    return call()
+
+# ================== lua script functions ==================
+
+def craft_conj_dict(scheme, old_data):
+    conj = {}
+
+    for field in re.split(r'[,]+', scheme):
+        field_value = old_data.get(field)
+
+        conj[field] = field_value
+
+    return conj
+
+
+def calculate_conj_key(prefix, db_table, old_data):
+    conj_keys = []
+    # return a set of binarty
+    schemes = redis_client.smembers(craft_scheme_key(prefix, db_table))
+    schemes = map(lambda s: s.decode('utf-8'), schemes)
+
+    for scheme in schemes:
+        conj = craft_conj_dict(scheme, old_data)
+        conj_keys.append(
+            craft_invalidator_key(prefix, db_table, conj)
+        )
+
+    return conj_keys
+
+
+def remove_chunk(client, data_keys):
+    for i in range(0, len(data_keys), 500):
+        client.delete(*data_keys[i: i + 500])
+
+
+def invalidation_dict_transaction(prefix, db_table, obj):
+    # not a part of transaction, since getting key may take a long time
+    # hence, we shouldn't include it
+
+    # step 1: create the pattern to get invalidation keys
+    conj_keys = calculate_conj_key(prefix, db_table, obj)
+    if not conj_keys:
+        return
+
+    # step 2: get all the invalidation keys
+    invalidation_keys = conj_keys
+    if not invalidation_keys:
+        return
+
+    # step 3: get all the data keys from invalidation keys
+    # each invalidation keys will hold a list of data keys
+    # simple diagram: invalidation-key -> data-key -> data
+    # so once we have a invalidation key,
+    # we will get all the data key it is holding and invalidate them
+    data_keys = list(redis_client.sunion(invalidation_keys))
+
+    # step 4: removal
+
+    # remove all data key and its data
+    remove_chunk(client=redis_client, data_keys=data_keys)
+
+    # remove all invalidation keys
+    redis_client.delete(*invalidation_keys)
+
+    # end invalidation transactions
+
+# =========================================
+
+@skip_on_no_invalidation
+@queue_when_in_transaction
+@handle_connection_failure
+def invalidate_dict(model, obj_dict, using=DEFAULT_DB_ALIAS):
+    """
+    This function is patched to remove the LUA Script from being used.
+    Since the Lua script can only run on 1 node
+
+    However, we are using redis cluster for a better scaling
+    -> This lead to some keys are not able to invalidate because of lua script limitation
+
+    To solve this,
+    I converted the lua script into python so that we can use RedisCluster client,
+    to perform invalidate action on multiple nodes
+
+    The logic of this function will be as close to the lua script as possible
+
+    Some code from lua script that only work with single node,
+    will be modified to work with multiple nodes
+    """
+    if (
+        no_invalidation.active or
+        not settings.CACHEOPS_ENABLED
+    ):
+        return
+
+    model = model._meta.concrete_model
+    prefix = get_prefix(
+        _cond_dnfs=[(model._meta.db_table,list(obj_dict.items()))],
+        dbs=[using]
+    )
+
+    # INFO: this part is removed since it only works on single redis cluster node
+    # load_script('invalidate')(keys=[prefix], args=[
+    #     model._meta.db_table,
+    #     json.dumps(obj_dict, default=str)
+    # ])
+
+    # move to use redis client = redis cluster client
+    # so that we can invalidate all the keys across multiple clusters
+    invalidation_dict_transaction(
+        prefix=prefix,
+        db_table=model._meta.db_table,
+        obj=obj_dict,
+    )
+
+    cache_invalidated.send(sender=model, obj_dict=obj_dict)
+
+
+
+@skip_on_no_invalidation
+def invalidate_obj(obj, using=DEFAULT_DB_ALIAS):
+    """
+    Invalidates caches that can possibly be influenced by object
+    """
+    model = obj.__class__._meta.concrete_model
+    invalidate_dict(model, get_obj_dict(model, obj), using=using)
+
+
+@skip_on_no_invalidation
+@queue_when_in_transaction
+@handle_connection_failure
+def invalidate_model(model, using=DEFAULT_DB_ALIAS):
+    """
+    Invalidates all caches for given model.
+    NOTE: This is a heavy artillery which uses redis KEYS request,
+          which could be relatively slow on large datasets.
+    """
+    model = model._meta.concrete_model
+    # NOTE: if we use sharding dependent on DNF then this will fail,
+    #       which is ok, since it's hard/impossible to predict all the shards
+    # !WARNING: performance issue on large dataset due to KEYS command search with pattern
+    conjs_keys = redis_client.keys("conj:%s:*" % (model._meta.db_table))
+    if conjs_keys:
+        cache_keys = redis_client.sunion(conjs_keys)
+        keys = list(cache_keys) + conjs_keys
+        redis_client.delete(*keys)
+    cache_invalidated.send(sender=model, obj_dict=None)
+
+
+@skip_on_no_invalidation
+@handle_connection_failure
+def invalidate_all():
+    redis_client.flushdb()
+    cache_invalidated.send(sender=None, obj_dict=None)
+
+
+class InvalidationState(threading.local):
+    def __init__(self):
+        self.depth = 0
+
+
+class _no_invalidation(ContextDecorator):
+    state = InvalidationState()
+
+    def __enter__(self):
+        self.state.depth += 1
+
+    def __exit__(self, type, value, traceback):
+        self.state.depth -= 1
+
+    @property
+    def active(self):
+        return self.state.depth
+
+no_invalidation = _no_invalidation()
+
+
+### ORM instance serialization
+
+@memoize
+def serializable_fields(model):
+    return {f for f in model._meta.fields
+              if f.get_internal_type() not in settings.CACHEOPS_SKIP_FIELDS}
+
+@post_processing(dict)
+def get_obj_dict(model, obj):
+    for field in serializable_fields(model):
+        # Skip deferred fields, in post_delete trying to fetch them results in error anyway.
+        # In post_save we rely on deferred values be the same as in pre_save.
+        if field.attname not in obj.__dict__:
+            continue
+
+        value = getattr(obj, field.attname)
+        if value is None:
+            yield field.attname, None
+        elif isinstance(value, (F, Expression)):
+            continue
+        else:
+            yield field.attname, field.get_prep_value(value)

--- a/cacheops/cluster/key_crafter.py
+++ b/cacheops/cluster/key_crafter.py
@@ -1,0 +1,26 @@
+def craft_scheme_key(prefix, table_name):
+    return f"{prefix}schemes:{table_name}"
+
+def craft_invalidator_key(prefix: str, db_table: str, conj: dict) -> str:
+    """
+    this function will generate the invalidator key
+    from the invalidator key, we can invalidate old data
+
+    invalidate_key -> data_key -> data
+
+    the invalidator key will have the following format
+    [prefix]conj:db_name:field1=value1&field2=value2
+
+    this function is named `conj_cache_key` in lua script
+
+    conj here is the dict contain field:value pair used by the filter query
+    note that conj will not contain Q class query
+    """
+    parts = []
+    for field, field_value in conj.items():
+        if field == '':
+            continue
+
+        parts.append(f"{field}={field_value}")
+
+    return f"{prefix}conj:{db_table}:{'&'.join(parts)}"

--- a/cacheops/cluster/lua/cache_thing.lua
+++ b/cacheops/cluster/lua/cache_thing.lua
@@ -1,0 +1,62 @@
+local prefix = KEYS[1]
+local key = KEYS[2]
+local precall_key = ARGV[1]
+local data = ARGV[2]
+local dnfs = cjson.decode(ARGV[3])
+local timeout = tonumber(ARGV[4])
+
+
+if precall_key ~= '' and redis.call('exists', precall_key) == 0 then
+  -- Cached data was invalidated during the function call. The data is
+  -- stale and should not be cached.
+  return
+end
+
+-- Write data to cache
+redis.call('setex', key, timeout, data)
+
+
+-- A pair of funcs
+-- NOTE: we depend here on keys order being stable
+local conj_schema = function (conj)
+    local parts = {}
+    for field, _ in pairs(conj) do
+        table.insert(parts, field)
+    end
+
+    return table.concat(parts, ',')
+end
+
+local conj_cache_key = function (db_table, conj)
+    local parts = {}
+    for field, val in pairs(conj) do
+        table.insert(parts, field .. '=' .. tostring(val))
+    end
+
+    return prefix .. 'conj:' .. db_table .. ':' .. table.concat(parts, '&')
+end
+
+
+-- Update schemes and invalidators
+for db_table, disj in pairs(dnfs) do
+    for _, conj in ipairs(disj) do
+        -- Ensure scheme is known
+        redis.call('sadd', prefix .. 'schemes:' .. db_table, conj_schema(conj))
+
+        -- Add new cache_key to list of dependencies
+        local conj_key = conj_cache_key(db_table, conj)
+        redis.call('sadd', conj_key, key)
+        -- NOTE: an invalidator should live longer than any key it references.
+        --       So we update its ttl on every key if needed.
+        -- NOTE: if CACHEOPS_LRU is True when invalidators should be left persistent,
+        --       so we strip next section from this script.
+        -- TOSTRIP
+        local conj_ttl = redis.call('ttl', conj_key)
+        if conj_ttl < timeout then
+            -- We set conj_key life with a margin over key life to call expire rarer
+            -- And add few extra seconds to be extra safe
+            redis.call('expire', conj_key, timeout * 2 + 10)
+        end
+        -- /TOSTRIP
+    end
+end

--- a/cacheops/cluster/lua/invalidate.lua
+++ b/cacheops/cluster/lua/invalidate.lua
@@ -1,0 +1,42 @@
+local prefix = KEYS[1]
+local db_table = ARGV[1]
+local obj = cjson.decode(ARGV[2])
+
+-- Utility functions
+local conj_cache_key = function (db_table, scheme, obj)
+    local parts = {}
+    for field in string.gmatch(scheme, "[^,]+") do
+        table.insert(parts, field .. '=' .. tostring(obj[field]))
+    end
+
+    return prefix .. 'conj:' .. db_table .. ':' .. table.concat(parts, '&')
+end
+
+local call_in_chunks = function (command, args)
+    local step = 1000
+    for i = 1, #args, step do
+        redis.call(command, unpack(args, i, math.min(i + step - 1, #args)))
+    end
+end
+
+
+-- Calculate conj keys
+local conj_keys = {}
+local schemes = redis.call('smembers', prefix .. 'schemes:' .. db_table)
+for _, scheme in ipairs(schemes) do
+    table.insert(conj_keys, conj_cache_key(db_table, scheme, obj))
+end
+
+
+-- Delete cache keys and refering conj keys
+if next(conj_keys) ~= nil then
+    local cache_keys = redis.call('sunion', unpack(conj_keys))
+    -- we delete cache keys since they are invalid
+    -- and conj keys as they will refer only deleted keys
+    redis.call("unlink", unpack(conj_keys))
+    if next(cache_keys) ~= nil then
+        -- NOTE: can't just do redis.call('del', unpack(...)) cause there is limit on number
+        --       of return values in lua.
+        call_in_chunks('del', cache_keys)
+    end
+end

--- a/cacheops/cluster/prefix_validator.py
+++ b/cacheops/cluster/prefix_validator.py
@@ -1,0 +1,21 @@
+import re
+
+
+class InvalidPrefix(Exception):
+    def __init__(self, prefix, message="prefix is not valid"):
+        self.prefix = prefix
+        self.message = f"{message} {prefix}"
+        super().__init__(self.message)
+
+
+def prefix_validator(prefix_fn):
+    hash_tag_regex = r"\{.*\}"
+
+    def wrapper(*args, **kwargs):
+        prefix = prefix_fn(*args, **kwargs)
+        if re.search(hash_tag_regex, prefix):
+            raise InvalidPrefix(prefix)
+
+        return prefix
+
+    return wrapper

--- a/cacheops/invalidator.py
+++ b/cacheops/invalidator.py
@@ -1,0 +1,17 @@
+from cacheops import invalidation
+from cacheops.conf import settings
+from cacheops.cluster import invalidation as cluster_invalidation
+
+class Invalidator(object):
+    """
+    Abstract layer to call correct invalidation function for cluster or normal mode
+    """
+    def __getattr__(self, name):
+        invalidator = cluster_invalidation if settings.CACHEOPS_CLUSTER_ENABLED else invalidation
+        res = getattr(invalidator, name)
+
+        # Save to dict to speed up next access, __getattr__ won't be called
+        self.__dict__[name] = res
+        return res
+
+invalidator = Invalidator()

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -27,9 +27,11 @@ from .utils import md5
 from .sharding import get_prefix
 from .redis import redis_client, handle_connection_failure, load_script
 from .tree import dnfs
-from .invalidation import invalidate_obj, invalidate_dict, skip_on_no_invalidation
+from .invalidator import invalidator
 from .transaction import transaction_states
 from .signals import cache_read
+
+from .cluster import cache_thing as cache_thing_cluster
 
 
 __all__ = ('cached_as', 'cached_view_as', 'install_cacheops')
@@ -48,6 +50,20 @@ def cache_thing(prefix, cache_key, data, cond_dnfs, timeout, dbs=(), precall_key
     # Could have changed after last check, sometimes superficially
     if transaction_states.is_dirty(dbs):
         return
+
+    if settings.CACHEOPS_CLUSTER_ENABLED:
+        cache_thing_cluster(
+            keys=[prefix, cache_key],
+            args=[
+                precall_key,
+                settings.CACHEOPS_SERIALIZER.dumps(data),
+                cond_dnfs,
+                timeout
+            ],
+            strip=settings.CACHEOPS_LRU,
+        )
+        return
+
     load_script('cache_thing', settings.CACHEOPS_LRU)(
         keys=[prefix, cache_key, precall_key],
         args=[
@@ -372,7 +388,7 @@ class QuerySetMixin(object):
         objs = self._no_monkey.bulk_create(self, objs, *args, **kwargs)
         if family_has_profile(self.model):
             for obj in objs:
-                invalidate_obj(obj, using=self.db)
+                invalidator.invalidate_obj(obj, using=self.db)
         return objs
 
     def invalidated_update(self, **kwargs):
@@ -390,7 +406,7 @@ class QuerySetMixin(object):
             new_objects = self.model.objects.filter(pk__in=pks).using(clone.db)
 
         for obj in chain(objects, new_objects):
-            invalidate_obj(obj, using=clone.db)
+            invalidator.invalidate_obj(obj, using=clone.db)
 
         return rows
 
@@ -426,7 +442,7 @@ class ManagerMixin(object):
         if cls.__module__ != '__fake__' and family_has_profile(cls):
             self._install_cacheops(cls)
 
-    @skip_on_no_invalidation
+    @invalidator.skip_on_no_invalidation
     def _pre_save(self, sender, instance, using, **kwargs):
         if instance.pk is not None and not instance._state.adding:
             try:
@@ -436,13 +452,13 @@ class ManagerMixin(object):
             except sender.DoesNotExist:
                 pass
 
-    @skip_on_no_invalidation
+    @invalidator.skip_on_no_invalidation
     def _post_save(self, sender, instance, using, **kwargs):
         # Invoke invalidations for both old and new versions of saved object
         old = _old_objs.__dict__.pop((sender, instance.pk), None)
         if old:
-            invalidate_obj(old, using=using)
-        invalidate_obj(instance, using=using)
+            invalidator.invalidate_obj(old, using=using)
+        invalidator.invalidate_obj(instance, using=using)
 
         invalidate_o2o(sender, old, instance, using=using)
 
@@ -492,7 +508,7 @@ class ManagerMixin(object):
         """
         # NOTE: this will behave wrong if someone changed object fields
         #       before deletion (why anyone will do that?)
-        invalidate_obj(instance, using=using)
+        invalidator.invalidate_obj(instance, using=using)
 
     def inplace(self):
         return self.get_queryset().inplace()
@@ -516,8 +532,8 @@ def invalidate_o2o(sender, old, instance, using=DEFAULT_DB_ALIAS):
         if old_value != value:
             rmodel, rfield = f.related_model, f.remote_field.field_name
             if old:
-                invalidate_dict(rmodel, {rfield: old_value}, using=using)
-            invalidate_dict(rmodel, {rfield: value}, using=using)
+                invalidator.invalidate_dict(rmodel, {rfield: old_value}, using=using)
+            invalidator.invalidate_dict(rmodel, {rfield: value}, using=using)
 
 
 def invalidate_m2m(sender=None, instance=None, model=None, action=None, pk_set=None, reverse=None,
@@ -542,12 +558,12 @@ def invalidate_m2m(sender=None, instance=None, model=None, action=None, pk_set=N
     if action == 'pre_clear':
         objects = sender.objects.using(using).filter(**{instance_column: instance.pk})
         for obj in objects:
-            invalidate_obj(obj, using=using)
+            invalidator.invalidate_obj(obj, using=using)
     elif action in ('post_add', 'pre_remove'):
         # NOTE: we don't need to query through objects here,
         #       cause we already know all their meaningful attributes.
         for pk in pk_set:
-            invalidate_dict(sender, {
+            invalidator.invalidate_dict(sender, {
                 instance_column: instance.pk,
                 model_column: pk
             }, using=using)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,5 @@ funcy>=1.8,<2.0
 six>=1.4.0
 before_after==1.0.0
 jinja2>=2.10
+redis-py-cluster>=2.0.0
 dill

--- a/run_tests_cluster.py
+++ b/run_tests_cluster.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import os, sys, re, shutil
+os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings_cluster'
+os.environ['CACHEOPS_DB'] = 'postgresql'
+
+# Use psycopg2cffi for PyPy
+try:
+    import psycopg2  # noqa
+except ImportError:
+    # Fall back to psycopg2cffi
+    try:
+        from psycopg2cffi import compat
+        compat.register()
+    except ImportError:
+        # Hope we are not testing against PostgreSQL :)
+        pass
+
+
+# Set up Django
+import django
+from django.core.management import call_command
+django.setup()
+
+
+# Derive test names
+names = next((a for a in sys.argv[1:] if not a.startswith('-')), None)
+if not names:
+    names = 'tests.cluster'
+elif re.search(r'^\d+', names):
+    names = 'tests.tests.IssueTests.test_' + names
+elif not names.startswith('tests.'):
+    names = 'tests.tests.' + names
+
+
+# NOTE: we create migrations each time  since they depend on type of database,
+#       python and django versions
+try:
+    shutil.rmtree('tests/migrations', True)
+    call_command('makemigrations', 'tests', verbosity=2 if '-v' in sys.argv else 0)
+    call_command('test', names, failfast='-x' in sys.argv, verbosity=2 if '-v' in sys.argv else 1)
+finally:
+    shutil.rmtree('tests/migrations', True)

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'redis>=3.0.0',
         'funcy>=1.8,<2.0',
         'six>=1.4.0',
+        'redis-py-cluster>=2.0.0',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -1,4 +1,4 @@
-from cacheops import invalidate_obj, invalidate_model
+from cacheops import invalidator
 from cacheops.conf import settings
 from cacheops.redis import redis_client
 from cacheops.tree import dnfs
@@ -29,7 +29,7 @@ def do_get_nocache():
 
 c = Category.objects.first()
 def invalidate_count():
-    invalidate_obj(c)
+    invalidator.invalidate_obj(c)
 
 def do_count():
     Category.objects.cache().count()
@@ -93,7 +93,7 @@ def prepare_obj():
     return Category.objects.cache().get(pk=1)
 
 def do_invalidate_obj(obj):
-    invalidate_obj(obj)
+    invalidator.invalidate_obj(obj)
 
 def do_save_obj(obj):
     obj.save()
@@ -155,7 +155,7 @@ def prepare_cache():
     return Extra.objects.cache().get(pk=1)
 
 def do_invalidate_model(obj):
-    invalidate_model(obj.__class__)
+    invalidator.invalidate_model(obj.__class__)
 
 
 TESTS = [

--- a/tests/cluster/test_extras.py
+++ b/tests/cluster/test_extras.py
@@ -5,8 +5,8 @@ from cacheops import cached_as, invalidator
 from cacheops.conf import settings
 from cacheops.signals import cache_read, cache_invalidated
 
-from .utils import BaseTestCase, make_inc
-from .models import Post, Category, Local, DbAgnostic, DbBinded
+from tests.utils import BaseTestCase, make_inc
+from tests.models import Post, Category, Local, DbAgnostic, DbBinded
 
 
 class SettingsTests(TestCase):
@@ -90,7 +90,7 @@ class LockingTests(BaseTestCase):
     def test_lock(self):
         import random
         import threading
-        from .utils import ThreadWithReturnValue
+        from tests.utils import ThreadWithReturnValue
         from before_after import before
 
         @cached_as(Post, lock=True, timeout=60)
@@ -104,7 +104,7 @@ class LockingTests(BaseTestCase):
         def second_thread():
             def _target():
                 try:
-                    with before('redis.StrictRedis.brpoplpush', lambda *a, **kw: locked.set()):
+                    with before('rediscluster.RedisCluster.brpoplpush', lambda *a, **kw: locked.set()):
                         results.append(func())
                 except Exception:
                     locked.set()

--- a/tests/cluster/tests.py
+++ b/tests/cluster/tests.py
@@ -18,8 +18,8 @@ from cacheops import invalidate_fragment
 from cacheops.templatetags.cacheops import register
 
 decorator_tag = register.decorator_tag
-from .models import *  # noqa
-from .utils import BaseTestCase, make_inc
+from tests.models import *  # noqa
+from tests.utils import BaseTestCase, make_inc
 
 
 class BasicTests(BaseTestCase):
@@ -644,9 +644,10 @@ class IssueTests(BaseTestCase):
 
         with self.assertRaises(AttributeError) as e:
             Client.objects.filter(name='Client Name').cache().first()
-        self.assertEqual(
-            str(e.exception),
-            "Can't pickle local object 'Client.__init__.<locals>.curry.<locals>._curried'")
+            self.assertEqual(
+                str(e.exception),
+                "Can't pickle local object 'Client.__init__.<locals>.curry.<locals>._curried'"
+            )
 
         invalidator.invalidate_model(Client)
 
@@ -910,7 +911,7 @@ class ProxyTests(BaseTestCase):
 
 
 class MultitableInheritanceTests(BaseTestCase):
-    @unittest.expectedFailure
+    # @unittest.expectedFailure
     def test_sub_added(self):
         media_count = Media.objects.cache().count()
         Movie.objects.create(name="Matrix", year=1999)
@@ -993,6 +994,7 @@ class MultiDBInvalidationTests(BaseTestCase):
         yield
         with self.assertNumQueries(0):
             Category.objects.cache().count()
+
         with self.assertNumQueries(1, using='slave'):
             Category.objects.cache().using('slave').count()
 
@@ -1017,7 +1019,7 @@ class MultiDBInvalidationTests(BaseTestCase):
         with self._control_counts():
             Category.objects.using('slave').invalidated_update(title='update')
 
-    @mock.patch('cacheops.invalidation.invalidate_dict')
+    @mock.patch('cacheops.cluster.invalidation.invalidate_dict')
     def test_m2m_changed_call_invalidate(self, mock_invalidate_dict):
         label = Label.objects.create()
         brand = Brand.objects.create()

--- a/tests/cluster/tests_sharding.py
+++ b/tests/cluster/tests_sharding.py
@@ -1,0 +1,61 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
+
+from cacheops import cache, CacheMiss
+from tests.models import Category, Post, Extra
+from tests.utils import BaseTestCase
+
+from cacheops.cluster.prefix_validator import InvalidPrefix
+
+
+class PrefixTests(BaseTestCase):
+    databases = ('default', 'slave')
+    fixtures = ['basic']
+
+    def test_context(self):
+        prefix = ['']
+        with override_settings(CACHEOPS_PREFIX=lambda _: prefix[0]):
+            with self.assertNumQueries(2):
+                Category.objects.cache().count()
+                prefix[0] = 'x'
+                Category.objects.cache().count()
+
+    @override_settings(CACHEOPS_PREFIX=lambda q: q.db)
+    def test_db(self):
+        with self.assertNumQueries(1):
+            list(Category.objects.cache())
+
+        with self.assertNumQueries(1, using='slave'):
+            list(Category.objects.cache().using('slave'))
+            list(Category.objects.cache().using('slave'))
+
+    @override_settings(CACHEOPS_PREFIX=lambda q: q.table)
+    def test_table(self):
+        self.assertTrue(Category.objects.all()._cache_key().startswith('tests_category'))
+
+        with self.assertRaises(ImproperlyConfigured):
+            list(Post.objects.filter(category__title='Django').cache())
+
+    @override_settings(CACHEOPS_PREFIX=lambda q: q.table)
+    def test_self_join_tables(self):
+        list(Extra.objects.filter(to_tag__pk=1).cache())
+
+    @override_settings(CACHEOPS_PREFIX=lambda q: q.table)
+    def test_union_tables(self):
+        qs = Post.objects.filter(pk=1).union(Post.objects.filter(pk=2)).cache()
+        list(qs)
+
+    @override_settings(CACHEOPS_PREFIX=lambda q: f"{{{q.table}}}")
+    def test_union_tables(self):
+        with self.assertRaises(InvalidPrefix):
+            qs = Post.objects.filter(pk=1).union(Post.objects.filter(pk=2)).cache()
+            list(qs)
+
+class SimpleCacheTests(BaseTestCase):
+    def test_prefix(self):
+        with override_settings(CACHEOPS_PREFIX=lambda _: 'a'):
+            cache.set("key", "value")
+            self.assertEqual(cache.get("key"), "value")
+
+        with self.assertRaises(CacheMiss):
+            cache.get("key")

--- a/tests/cluster/tests_transactions.py
+++ b/tests/cluster/tests_transactions.py
@@ -1,0 +1,135 @@
+from django.db import connection, IntegrityError
+from django.db.transaction import atomic
+from django.test import TransactionTestCase
+
+from cacheops.transaction import queue_when_in_transaction
+
+from tests.models import Category, Post
+from tests.utils import run_in_thread
+
+
+def get_category():
+    return Category.objects.cache().get(pk=1)
+
+
+class IntentionalRollback(Exception):
+    pass
+
+
+class TransactionSupportTests(TransactionTestCase):
+    databases = ('default', 'slave')
+    fixtures = ['basic']
+
+    def test_atomic(self):
+        with atomic():
+            obj = get_category()
+            obj.title = 'Changed'
+            obj.save()
+            self.assertEqual('Changed', get_category().title)
+            self.assertEqual('Django', run_in_thread(get_category).title)
+        self.assertEqual('Changed', run_in_thread(get_category).title)
+        self.assertEqual('Changed', get_category().title)
+
+    def test_nested(self):
+        with atomic():
+            with atomic():
+                obj = get_category()
+                obj.title = 'Changed'
+                obj.save()
+                self.assertEqual('Changed', get_category().title)
+                self.assertEqual('Django', run_in_thread(get_category).title)
+            self.assertEqual('Changed', get_category().title)
+            self.assertEqual('Django', run_in_thread(get_category).title)
+        self.assertEqual('Changed', run_in_thread(get_category).title)
+        self.assertEqual('Changed', get_category().title)
+
+    def test_rollback(self):
+        try:
+            with atomic():
+                obj = get_category()
+                obj.title = 'Changed'
+                obj.save()
+                self.assertEqual('Changed', get_category().title)
+                self.assertEqual('Django', run_in_thread(get_category).title)
+                raise IntentionalRollback()
+        except IntentionalRollback:
+            pass
+        self.assertEqual('Django', get_category().title)
+        self.assertEqual('Django', run_in_thread(get_category).title)
+
+    def test_nested_rollback(self):
+        with atomic():
+            try:
+                with atomic():
+                    obj = get_category()
+                    obj.title = 'Changed'
+                    obj.save()
+                    self.assertEqual('Changed', get_category().title)
+                    self.assertEqual('Django', run_in_thread(get_category).title)
+                    raise IntentionalRollback()
+            except IntentionalRollback:
+                pass
+            self.assertEqual('Django', get_category().title)
+            self.assertEqual('Django', run_in_thread(get_category).title)
+        self.assertEqual('Django', get_category().title)
+        self.assertEqual('Django', run_in_thread(get_category).title)
+
+    def test_smart_transactions(self):
+        with atomic():
+            get_category()
+            with self.assertNumQueries(0):
+                get_category()
+            with atomic():
+                with self.assertNumQueries(0):
+                    get_category()
+
+            obj = get_category()
+            obj.title += ' changed'
+            obj.save()
+
+            get_category()
+            with self.assertNumQueries(1):
+                get_category()
+
+    def test_rollback_during_integrity_error(self):
+        # store category in cache
+        get_category()
+
+        # Make current DB be "dirty" by write
+        try:
+            with atomic():
+                Post.objects.create(category_id=-1, title='')
+        except IntegrityError:
+            # however, this write should be rolled back and current DB should
+            # not be "dirty"
+            pass
+
+        with self.assertNumQueries(0):
+            get_category()
+
+    def test_call_cacheops_cbs_before_on_commit_cbs(self):
+        calls = []
+
+        with atomic():
+            def django_commit_handler():
+                calls.append('django')
+            connection.on_commit(django_commit_handler)
+
+            @queue_when_in_transaction
+            def cacheops_commit_handler(using):
+                calls.append('cacheops')
+            cacheops_commit_handler('default')
+
+        self.assertEqual(calls, ['cacheops', 'django'])
+
+    def test_multidb(self):
+        try:
+            with atomic('slave'):
+                with atomic():
+                    obj = get_category()
+                    obj.title = 'Changed'
+                    obj.save()
+                raise IntentionalRollback()
+        except IntentionalRollback:
+            pass
+        self.assertEqual('Changed', get_category().title)

--- a/tests/settings_cluster.py
+++ b/tests/settings_cluster.py
@@ -1,0 +1,128 @@
+import os
+
+INSTALLED_APPS = [
+    'cacheops',
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
+    'tests',
+]
+
+ROOT_URLCONF = 'tests.urls'
+
+MIDDLEWARE_CLASSES = []
+
+AUTH_PROFILE_MODULE = 'tests.UserProfile'
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+# Django replaces this, but it still wants it. *shrugs*
+DATABASE_ENGINE = 'django.db.backends.sqlite3',
+if os.environ.get('CACHEOPS_DB') == 'postgresql':
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': 'cacheops',
+            'USER': 'cacheops',
+            'PASSWORD': '',
+            'HOST': ''
+        },
+        'slave': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': 'cacheops_slave',
+            'USER': 'cacheops',
+            'PASSWORD': '',
+            'HOST': ''
+        },
+    }
+elif os.environ.get('CACHEOPS_DB') == 'postgis':
+    POSTGIS_VERSION = (2, 1, 1)
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.contrib.gis.db.backends.postgis',
+            'NAME': 'cacheops',
+            'USER': 'cacheops',
+            'PASSWORD': '',
+            'HOST': '',
+        },
+        'slave': {
+            'ENGINE': 'django.contrib.gis.db.backends.postgis',
+            'NAME': 'cacheops_slave',
+            'USER': 'cacheops',
+            'PASSWORD': '',
+            'HOST': '',
+        },
+    }
+elif os.environ.get('CACHEOPS_DB') == 'mysql':
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': 'cacheops',
+            'USER': 'cacheops',
+            'PASSWORD': '',
+            'HOST': '',
+        },
+        'slave': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': 'cacheops_slave',
+            'USER': 'cacheops',
+            'PASSWORD': '',
+            'HOST': '',
+        },
+    }
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': 'sqlite.db',
+            # Make in memory sqlite test db to work with threads
+            # See https://code.djangoproject.com/ticket/12118
+            'TEST': {
+                'NAME': ':memory:cache=shared'
+            }
+        },
+        'slave': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': 'sqlite_slave.db',
+        }
+    }
+
+
+CACHEOPS_REDIS = {
+    'startup_nodes': 'localhost:6379',
+    # lazy starting redis client
+    'skip_full_coverage_check': True,
+    'init_slot_cache': False
+}
+
+
+def handle_timeout_error(e, *args, **kwargs):
+    print(e, *args, **kwargs)
+    
+
+
+CACHEOPS_CLUSTER_ENABLED = True
+CACHEOPS_REDIS_CONNECTION_TIMEOUT = 1
+CACHEOPS_TIMEOUT_HANDLER = handle_timeout_error
+CACHEOPS_DEFAULTS = {
+    'timeout': 60*60
+}
+CACHEOPS = {
+    'tests.local': {'local_get': True},
+    'tests.cacheonsavemodel': {'cache_on_save': True},
+    'tests.dbbinded': {'db_agnostic': False},
+    'tests.*': {},
+    'tests.noncachedvideoproxy': None,
+    'tests.noncachedmedia': None,
+    'auth.*': {},
+}
+
+if os.environ.get('CACHEOPS_PREFIX'):
+    CACHEOPS_PREFIX = lambda q: 'p:'
+
+CACHEOPS_LRU = bool(os.environ.get('CACHEOPS_LRU'))
+CACHEOPS_DEGRADE_ON_FAILURE = bool(os.environ.get('CACHEOPS_DEGRADE_ON_FAILURE'))
+ALLOWED_HOSTS = ['testserver']
+
+SECRET_KEY = 'abc'
+
+TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates'}]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from cacheops import invalidate_all
+from cacheops import invalidator
 from cacheops.transaction import transaction_states
 
 
@@ -13,7 +13,7 @@ class BaseTestCase(TestCase):
         transaction_states._states, self._states \
             = empty(transaction_states._states), transaction_states._states
 
-        invalidate_all()
+        invalidator.invalidate_all()
 
     def tearDown(self):
         transaction_states._states = self._states


### PR DESCRIPTION
- In this PR, we have added the support for cluster mode to django-cacheops
- The feature is toggle-able via `CACHEOPS_CLUSTER_ENABLED` flag
- In order to make it works, we moved the logic from the Lua scripts to Python with the support of RedisCluster client from `redis-py-cluster` package
- We also created tests (inherited from normal tests) for cluster mode, people can run it by running `run_tests_cluster.py` file
- While we were implementing this mode, we wanted all the keys will be distributed evenly. That's why we added a prefix check in cluster mode to prevent user adding a redis hashtag to the prefix, which will lead to unbalanced key distribution.
