### PR TITLE
Test related to issue 404

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -677,8 +677,9 @@ class IssueTests(BaseTestCase):
         categories = Category.objects.filter(title='Django').values_list('id', flat=True).nocache()
         self.assertEquals(2, len(categories))
         with self.assertNumQueries(0):
-            list(visible_posts.filter(id__in=categories).cache())    # From DB
-            list(visible_posts.filter(id__in=categories).cache())    # From cache
+            # The subquey is the same so this is from the cache so 
+            # the new categories values are not taken into account
+            list(visible_posts.filter(id__in=categories).cache())    
             
 
 class RelatedTests(BaseTestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -674,7 +674,6 @@ class IssueTests(BaseTestCase):
             list(visible_posts.filter(id__in=categories))    # From cache
             
         categories = Category.objects.filter(id=3).values_list('id', flat=True)
-        visible_posts = Post.objects.filter(visible=True)
         with self.assertNumQueries(1):
             list(visible_posts.filter(id__in=categories))    # From DB
             list(visible_posts.filter(id__in=categories))    # From cache

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -661,7 +661,8 @@ class IssueTests(BaseTestCase):
         post.delete()
     
     def test_404(self):
-        categories = Category.objects.filter(id=1).values_list('id', flat=True).nocache()
+        categories = Category.objects.filter(title='Django').values_list('id', flat=True).nocache()
+        self.assertEquals(1, len(categories))
         visible_posts = Post.objects.filter(visible=True).cache()
             
         with self.assertNumQueries(1):
@@ -671,9 +672,11 @@ class IssueTests(BaseTestCase):
         with self.assertNumQueries(1):
             list(visible_posts.filter(id__in=categories).cache())    # From DB
             list(visible_posts.filter(id__in=categories).cache())    # From cache
-            
-        categories = Category.objects.filter(id=3).values_list('id', flat=True).nocache()
-        with self.assertNumQueries(1):
+        
+        Category.objects.create(title='Django')
+        categories = Category.objects.filter(title='Django').values_list('id', flat=True).nocache()
+        self.assertEquals(2, len(categories))
+        with self.assertNumQueries(0):
             list(visible_posts.filter(id__in=categories).cache())    # From DB
             list(visible_posts.filter(id__in=categories).cache())    # From cache
             

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -660,23 +660,22 @@ class IssueTests(BaseTestCase):
         post = Post.objects.defer("visible").last()
         post.delete()
     
-    @override_settings(CACHEOPS = {'tests.post': {'ops': {'get', 'fetch'}},})
     def test_404(self):
-        categories = Category.objects.filter(id=1).values_list('id', flat=True)
-        visible_posts = Post.objects.filter(visible=True)
+        categories = Category.objects.filter(id=1).values_list('id', flat=True).nocache()
+        visible_posts = Post.objects.filter(visible=True).cache()
             
         with self.assertNumQueries(1):
             list(visible_posts)     # From DB
             list(visible_posts)     # From cache
 
         with self.assertNumQueries(1):
-            list(visible_posts.filter(id__in=categories))    # From DB
-            list(visible_posts.filter(id__in=categories))    # From cache
+            list(visible_posts.filter(id__in=categories).cache())    # From DB
+            list(visible_posts.filter(id__in=categories).cache())    # From cache
             
-        categories = Category.objects.filter(id=3).values_list('id', flat=True)
+        categories = Category.objects.filter(id=3).values_list('id', flat=True).nocache()
         with self.assertNumQueries(1):
-            list(visible_posts.filter(id__in=categories))    # From DB
-            list(visible_posts.filter(id__in=categories))    # From cache
+            list(visible_posts.filter(id__in=categories).cache())    # From DB
+            list(visible_posts.filter(id__in=categories).cache())    # From cache
             
 
 class RelatedTests(BaseTestCase):


### PR DESCRIPTION
This is the test for issue 404, this line it doesn't work '@override_settings(CACHEOPS = {'tests.post': {'ops': {'get', 'fetch'}},})' to be able to make it work I changed in my local the global settings  to
```CACHEOPS = {'tests.post': {'ops': {'get', 'fetch'}},}```
But I didn't push it, because I know it should be another way to do it.
Also here my test pass, so this is even more confuse for me