### PR TITLE
Fix for precall key when a prefix is defined

### DIFF
--- a/cacheops/lua/cache_thing.lua
+++ b/cacheops/lua/cache_thing.lua
@@ -5,7 +5,7 @@ local data = ARGV[1]
 local dnfs = cjson.decode(ARGV[2])
 local timeout = tonumber(ARGV[3])
 
-if precall_key ~= '' and redis.call('exists', precall_key) == 0 then
+if precall_key ~= prefix and redis.call('exists', precall_key) == 0 then
   -- Cached data was invalidated during the function call. The data is
   -- stale and should not be cached.
   return

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -48,6 +48,8 @@ def cache_thing(prefix, cache_key, data, cond_dnfs, timeout, dbs=(), precall_key
     # Could have changed after last check, sometimes superficially
     if transaction_states.is_dirty(dbs):
         return
+    if prefix and precall_key == "":
+        precall_key = prefix
     load_script('cache_thing', settings.CACHEOPS_LRU)(
         keys=[prefix, cache_key, precall_key],
         args=[


### PR DESCRIPTION
If a Redis user is restricted to a specific key prefix namespace, it will block the script from running with an empty key.