### PR TITLE
Fix `invalidate_m2o` for polymorphic models

### DIFF
--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -529,10 +529,12 @@ def invalidate_m2o(sender, instance, using=DEFAULT_DB_ALIAS):
     """Invoke invalidation for m2o and m2m queries to a deleted instance"""
     all_fields = sender._meta.get_fields(include_hidden=True, include_parents=True)
     m2o_fields = [f for f in all_fields if isinstance(f, models.ManyToOneRel)]
+    fk_fields_names_map = {
+        f.name: f.attname
+        for f in all_fields if isinstance(f, models.ForeignKey)
+    }
     for f in m2o_fields:
-        attr = f.field_name
-        if f.field_name == sender._meta.pk.name:
-            attr = sender._meta.pk.attname
+        attr = fk_fields_names_map.get(f.field_name, f.field_name)
         value = getattr(instance, attr)
         rmodel, rfield = f.related_model, f.remote_field.attname
         invalidate_dict(rmodel, {rfield: value}, using=using)

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -530,7 +530,10 @@ def invalidate_m2o(sender, instance, using=DEFAULT_DB_ALIAS):
     all_fields = sender._meta.get_fields(include_hidden=True, include_parents=True)
     m2o_fields = [f for f in all_fields if isinstance(f, models.ManyToOneRel)]
     for f in m2o_fields:
-        value = getattr(instance, f.field_name)
+        attr = f.field_name
+        if f.field_name == sender._meta.pk.name:
+            attr = sender._meta.pk.attname
+        value = getattr(instance, attr)
         rmodel, rfield = f.related_model, f.remote_field.attname
         invalidate_dict(rmodel, {rfield: value}, using=using)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -165,6 +165,7 @@ class Media(models.Model):
     def __str__(self):
         return str(self.media_type)
 
+
 class Movie(Media):
     year = models.IntegerField()
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -151,13 +151,32 @@ class MediaProxy(NonCachedMedia):
         proxy = True
 
 
+class MediaType(models.Model):
+    name = models.CharField(max_length=50)
+
 # Multi-table inheritance
 class Media(models.Model):
     name = models.CharField(max_length=128)
+    media_type = models.ForeignKey(
+        MediaType,
+        on_delete=models.CASCADE,
+    )
+
+    def __str__(self):
+        return str(self.media_type)
 
 class Movie(Media):
     year = models.IntegerField()
 
+
+class Scene(models.Model):
+    """Model with FK to submodel."""
+    name = models.CharField(max_length=50)
+    movie = models.ForeignKey(
+        Movie,
+        on_delete=models.CASCADE,
+        related_name="scenes",
+    )
 
 # M2M models
 class Label(models.Model):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -696,9 +696,10 @@ class IssueTests(BaseTestCase):
             movie=movie,
         )
         invalidate_m2o(Movie, movie)
-        obj_dict = mock_invalidate_dict.call_args[0][1]
-        self.assertFalse(isinstance(obj_dict['movie_id'], Media))
-        self.assertTrue(isinstance(obj_dict['movie_id'], int))
+
+        obj_movie_dict = mock_invalidate_dict.call_args[0][1]
+        self.assertFalse(isinstance(obj_movie_dict['movie_id'], Media))
+        self.assertTrue(isinstance(obj_movie_dict['movie_id'], int))
 
     def test_430_no_error_raises(self):
         media_type = MediaType.objects.create(


### PR DESCRIPTION
Now there is problem with polymorphic models and `invalidate_m2o`.
When Model is inherited it's pk field is `OneToOne` field to parent model. And if there is some other model with FK to inherited model, this FK points to `OneToOne` field. In this situation `getattr(instance, f.field_name)` will return model instance of parent model, when we need to get `id`.

We can fix it using Model._meta.pk.attname.
Test case presented.
Can you please add this fix to 6.1