### PR TITLE
docs: Fix a few typos

### DIFF
--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -183,7 +183,7 @@ class QuerySetMixin(object):
         # If query results differ depending on database
         if self._cacheprofile and not self._cacheprofile['db_agnostic']:
             md.update(self.db)
-        # Iterable class pack results diffrently
+        # Iterable class pack results differently
         it_class = self._iterable_class
         md.update('%s.%s' % (it_class.__module__, it_class.__name__))
 
@@ -217,7 +217,7 @@ class QuerySetMixin(object):
             timeout    - override default cache timeout
             lock       - use lock to prevent dog-pile effect
 
-        NOTE: you actually can disable caching by omiting corresponding ops,
+        NOTE: you actually can disable caching by omitting corresponding ops,
               .cache(ops=[]) disables caching for this queryset.
         """
         self._require_cacheprofile()
@@ -287,7 +287,7 @@ class QuerySetMixin(object):
 
     def count(self):
         if self._should_cache('count'):
-            # Optmization borrowed from overriden method:
+            # Optmization borrowed from overridden method:
             # if queryset cache is already filled just return its len
             if self._result_cache is not None:
                 return len(self._result_cache)
@@ -331,7 +331,7 @@ class QuerySetMixin(object):
                     and not self.query.select_related \
                     and not self.query.where.children:
                 # NOTE: We use simpler way to generate a cache key to cut costs.
-                #       Some day it could produce same key for diffrent requests.
+                #       Some day it could produce same key for different requests.
                 key = (self.__class__, self.model) + tuple(sorted(kwargs.items()))
                 try:
                     return _local_get_cache[key]

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -15,7 +15,7 @@ def get_concrete_model(model):
 
 def model_family(model):
     """
-    Returns a list of all proxy models, including subclasess, superclassses and siblings.
+    Returns a list of all proxy models, including subclasess, superclasses and siblings.
     """
     def class_tree(cls):
         return [cls] + lmapcat(class_tree, cls.__subclasses__())

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -485,7 +485,7 @@ class IssueTests(BaseTestCase):
         brand.labels.add(label)
 
         # Create another brand with the same pk as label.
-        # This will trigger a bug invalidating brands quering them by label id.
+        # This will trigger a bug invalidating brands querying them by label id.
         another_brand = Brand.objects.create(pk=2)
 
         list(brand.labels.cache())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -48,7 +48,7 @@ class ThreadWithReturnValue(Thread):
             self._exc = e
         finally:
             # Django does not drop postgres connections opened in new threads.
-            # This leads to postgres complaining about db accessed when we try to destory it.
+            # This leads to postgres complaining about db accessed when we try to destroy it.
             # See https://code.djangoproject.com/ticket/22420#comment:18
             from django.db import connection
             connection.close()


### PR DESCRIPTION
There are small typos in:
- cacheops/query.py
- cacheops/utils.py
- tests/tests.py
- tests/utils.py

Fixes:
- Should read `superclasses` rather than `superclassses`.
- Should read `querying` rather than `quering`.
- Should read `overridden` rather than `overriden`.
- Should read `omitting` rather than `omiting`.
- Should read `differently` rather than `diffrently`.
- Should read `different` rather than `diffrent`.
- Should read `destroy` rather than `destory`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md