### PR TITLE
Remove not needed six dependency

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,6 @@
 django>=1.8
 redis>=3.0.0
 funcy>=1.8,<2.0
-six>=1.4.0
 before_after==1.0.0
 jinja2>=2.10
 dill

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'django>=2.1',
         'redis>=3.0.0',
         'funcy>=1.8,<2.0',
-        'six>=1.4.0',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
The six package is not required anymore, python2 support was removed in https://github.com/Suor/django-cacheops/commit/19c36b2bb51aa05188ee8f6ad23cac1f850d7c66