### PR TITLE
fix abstract models that do not have an application

### DIFF
--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -99,6 +99,9 @@ def model_profile(model):
     # Django migrations these fake models, we don't want to cache them
     if model.__module__ == '__fake__':
         return None
+    # FIX UpdateReturningModel form django_pg_returning
+    elif model._meta.app_label is None and model._meta.abstract:
+        return None
 
     model_profiles = prepare_profiles()
 


### PR DESCRIPTION
Solving the problem when trying to handle the cache for abstract models that do not have an application (for third-party django applications)