### PR TITLE
Don't WRONGTYPE when activating CACHEOPS_INSIDEOUT with cached conj sets

### DIFF
--- a/cacheops/lua/cache_thing_insideout.lua
+++ b/cacheops/lua/cache_thing_insideout.lua
@@ -15,7 +15,8 @@ end
 local stamps = {}
 local rnd = tostring(math.random())  -- A new value for empty stamps
 for _, conj_key in ipairs(conj_keys) do
-    local stamp = redis.call('set', conj_key, rnd, 'nx', 'get') or rnd
+    local stamp = redis.pcall('set', conj_key, rnd, 'nx', 'get')
+    if not stamp or stamp['err'] ~= nil then stamp = rnd end
     table.insert(stamps, stamp)
     -- NOTE: an invalidator should live longer than any key it references.
     --       So we update its ttl on every key if needed.


### PR DESCRIPTION
`CACHEOPS_INSIDEOUT` works by storing a random number for the `conj:` key and prefixing a checksum of those numbers to each stored resultset.

But without `CACHEOPS_INSIDEOUT` `conj:` keys have set values.

So if the application's cache already contains conj sets when `CACHEOPS_INSIDEOUT` is first activated, [the `cache_thing_insideout.lua` script](https://github.com/Suor/django-cacheops/blob/7.0.1/cacheops/lua/cache_thing_insideout.lua) will fail with
```
WRONGTYPE Operation against a key holding the wrong kind of value script: 4dfdfcbcc31ed3e8e9cdff232badd0f18547971b, on @user_script:18.
```
when it tries to `SET ... GET` the key, since you can't `GET` a set.

This PR changes the `cache_thing_insideout.lua` script to [`redis.pcall()`](https://redis.io/docs/manual/programmability/lua-api/#redis.pcall) the `SET ... GET` and handle the error.
