### PR TITLE
migrate from external mock package to stdlib unittest.mock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.10"]
         experimental: [false]
         include:
           - python-version: "3.10"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 import re
 import platform
 import unittest
-import mock
+from unittest import mock
 
 import django
 from django.db import connection

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py{38,39}-dj{32,40},
     py310-dj{32,40,41},
     py311-dj{41,42},
-    pypy39-dj40
+    pypy310-dj40
 
 [gh-actions]
 python =
@@ -14,7 +14,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
-    pypy-3.9: pypy39
+    pypy-3.10: pypy310
 
 
 [testenv]
@@ -35,7 +35,7 @@ deps =
     mysqlclient
     py{37,38,39,310,311}: psycopg2-binary
     ; gdal=={env:GDAL_VERSION:2.4}
-    pypy39: psycopg2cffi>=2.7.6
+    pypy310: psycopg2cffi>=2.7.6
     before_after==1.0.0
     jinja2>=2.10
     dill


### PR DESCRIPTION
It was moved to the stdlib in python 3.3, and the PyPI version is a backport for python versions less than 3.3.

Note: it was also never a dependendency so there was no guarantee it was installed to be used.