### PR TITLE
user_script error in insideout mode

### DIFF
--- a/cacheops/getset.py
+++ b/cacheops/getset.py
@@ -142,5 +142,5 @@ def dnfs_to_conj_keys(prefix, cond_dnfs):
                                          for conj in disj]
 
 def dnfs_to_schemes(cond_dnfs):
-    return {table: [",".join(sorted(conj)) for conj in disj]
+    return {table: list({",".join(sorted(conj)) for conj in disj})
             for table, disj in cond_dnfs.items() if disj}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,6 @@
 from contextlib import contextmanager
+from functools import reduce
+import operator
 import re
 import platform
 import unittest
@@ -717,6 +719,19 @@ class IssueTests(BaseTestCase):
         )
         # no error raises on delete
         media_type.delete()
+
+    def test_480(self):
+        orm_lookups = ['title__icontains', 'category__title__icontains', ]
+        search_terms = ['1', "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"]
+        queryset = Post.objects.filter(visible=True)
+        conditions = []
+        for search_term in search_terms:
+            queries = [
+                models.Q(**{orm_lookup: search_term})
+                for orm_lookup in orm_lookups
+            ]
+            conditions.append(reduce(operator.or_, queries))
+        list(queryset.filter(reduce(operator.and_, conditions)).cache())
 
 
 class RelatedTests(BaseTestCase):


### PR DESCRIPTION
Hi! I am using insideout mode.
In search filters I often get the error
"user_script:12: too many results to unpack script" in lua script.
I noticed that for none tag filters dnfs is too big. For example, in the testcase dnfs_to_schemes produces a list with 2^n elements. If we add another nested field for search, the number of keys increases dramatically.
I think more complex optimization at "tree to dnfs" may be needed here, but btw added qfix for this error