### PR TITLE
Update md5 to set usedforsecurity for FIPS compliance

### DIFF
--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -151,7 +151,7 @@ class md5:
         # this is for backwards compatibility
         pyversion = sys.version_info
         if (pyversion.major == 3 and pyversion.minor >= 9) or pyversion.major > 3:
-            md5_kwargs["usedforsecuirty"] = False
+            md5_kwargs["usedforsecurity"] = False
 
         self.md5 = hashlib.md5(**md5_kwargs)
         if s is not None:

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -143,7 +143,7 @@ import hashlib
 
 class md5:
     def __init__(self, s=None):
-        self.md5 = hashlib.md5()
+        self.md5 = hashlib.md5(usedforsecurity=False)
         if s is not None:
             self.update(s)
 

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -1,6 +1,7 @@
 import re
 import json
 import inspect
+import sys
 from funcy import memoize, compose, wraps, any, any_fn, select_values, mapcat
 
 from django.db import models
@@ -143,7 +144,16 @@ import hashlib
 
 class md5:
     def __init__(self, s=None):
-        self.md5 = hashlib.md5(usedforsecurity=False)
+        md5_kwargs = {}
+
+        # set usedforsecurity for FIPS compliance
+        # usedforsecurity was introduced in 3.9
+        # this is for backwards compatibility
+        pyversion = sys.version_info
+        if pyversion.major == 3 and pyversion.minor >= 9:
+            md5_kwargs["usedforsecuirty"] = False
+
+        self.md5 = hashlib.md5(**md5_kwargs)
         if s is not None:
             self.update(s)
 

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -150,7 +150,7 @@ class md5:
         # usedforsecurity was introduced in 3.9
         # this is for backwards compatibility
         pyversion = sys.version_info
-        if pyversion.major == 3 and pyversion.minor >= 9:
+        if (pyversion.major == 3 and pyversion.minor >= 9) or pyversion.major > 3:
             md5_kwargs["usedforsecuirty"] = False
 
         self.md5 = hashlib.md5(**md5_kwargs)


### PR DESCRIPTION
For FIPS compliance, MD5 is not an allowed hashing algorithm when used for security. [In 3.9, `usedforsecurity` was introduced to flag non-security use of the algo.](https://docs.python.org/3/library/hashlib.html#hash-algorithms) 

This PR adds the `usedforsecurity` attribute to the instantiation with backwards compatibility for earlier Python versions. 