### PR TITLE
Django 5.2 compatibility: prefetch related rely on TupleIn lookup

### DIFF
--- a/cacheops/tree.py
+++ b/cacheops/tree.py
@@ -20,6 +20,12 @@ except ImportError:
     class SubqueryConstraint(object):
         pass
 
+try:
+    from django.db.models.fields.tuple_lookups import TupleIn
+except ImportError:
+    class TupleIn(object):
+        pass
+
 
 def dnfs(qs):
     """
@@ -46,6 +52,29 @@ def dnfs(qs):
         Any conditions other then eq are dropped.
         """
         if isinstance(where, Lookup):
+            if hasattr(where.lhs, 'targets'):
+                attnames = ','.join(t.attname for t in where.lhs.targets)
+                # since django5.2, prefetch_related rely on TupleIn and ColPair
+                if (
+                    isinstance(where, TupleIn)
+                    and len(where.rhs) < settings.CACHEOPS_LONG_DISJUNCTION
+                ):
+                    return {
+                        frozenset(
+                            {
+                                (
+                                    where.lhs.alias,
+                                    attnames,
+                                    ','.join(str(v) for v in values),
+                                    True,
+                                )
+                            }
+                        )
+                        for values in where.rhs
+                    }
+                else:
+                    # TODO: add other tuple lookup
+                    return SOME_TREE
             # If where.lhs don't refer to a field then don't bother
             if not hasattr(where.lhs, 'target'):
                 return SOME_TREE

--- a/cacheops/tree.py
+++ b/cacheops/tree.py
@@ -53,24 +53,23 @@ def dnfs(qs):
         """
         if isinstance(where, Lookup):
             if hasattr(where.lhs, 'targets'):
-                attnames = ','.join(t.attname for t in where.lhs.targets)
                 # since django5.2, prefetch_related rely on TupleIn and ColPair
                 if (
                     isinstance(where, TupleIn)
                     and len(where.rhs) < settings.CACHEOPS_LONG_DISJUNCTION
                 ):
+                    # return result like AND condition
                     return {
                         frozenset(
-                            {
-                                (
-                                    where.lhs.alias,
-                                    attnames,
-                                    ','.join(str(v) for v in values),
-                                    True,
-                                )
-                            }
+                            (
+                                where.lhs.alias,
+                                target.attname,
+                                value,
+                                True,
+                            )
+                            for values in where.rhs
+                            for target, value in zip(where.lhs.targets, values)
                         )
-                        for values in where.rhs
                     }
                 else:
                     # TODO: add other tuple lookup

--- a/tests/models.py
+++ b/tests/models.py
@@ -308,6 +308,20 @@ class Client(models.Model):
 
     name = models.CharField(max_length=255)
 
+# composite primary keys
+class Product(models.Model):
+    name = models.CharField(max_length=100)
+
+
+class Order(models.Model):
+    reference = models.CharField(max_length=20, primary_key=True)
+
+
+class OrderLineItem(models.Model):
+    pk = models.CompositePrimaryKey("product_id", "order_id")
+    product = models.ForeignKey(Product, on_delete=models.CASCADE)
+    order = models.ForeignKey(Order, on_delete=models.CASCADE)
+    quantity = models.IntegerField()
 
 # Abstract models
 class Abs(models.Model):

--- a/tests/models.py
+++ b/tests/models.py
@@ -2,6 +2,7 @@ import os
 import uuid
 from datetime import date, time
 
+from django import VERSION as DJANGO_VERSION
 from django.db import models
 from django.db.models.query import QuerySet
 from django.db.models import sql, manager
@@ -308,20 +309,21 @@ class Client(models.Model):
 
     name = models.CharField(max_length=255)
 
-# composite primary keys
-class Product(models.Model):
-    name = models.CharField(max_length=100)
+# composite primary keys available for django 5.2+
+if DJANGO_VERSION >= (5, 2):
+    class Product(models.Model):
+        name = models.CharField(max_length=100)
 
 
-class Order(models.Model):
-    reference = models.CharField(max_length=20, primary_key=True)
+    class Order(models.Model):
+        reference = models.CharField(max_length=20, primary_key=True)
 
 
-class OrderLineItem(models.Model):
-    pk = models.CompositePrimaryKey("product_id", "order_id")
-    product = models.ForeignKey(Product, on_delete=models.CASCADE)
-    order = models.ForeignKey(Order, on_delete=models.CASCADE)
-    quantity = models.IntegerField()
+    class OrderLineItem(models.Model):
+        pk = models.CompositePrimaryKey("product_id", "order_id")
+        product = models.ForeignKey(Product, on_delete=models.CASCADE)
+        order = models.ForeignKey(Order, on_delete=models.CASCADE)
+        quantity = models.IntegerField()
 
 # Abstract models
 class Abs(models.Model):

--- a/tests/models.py
+++ b/tests/models.py
@@ -314,10 +314,8 @@ if DJANGO_VERSION >= (5, 2):
     class Product(models.Model):
         name = models.CharField(max_length=100)
 
-
     class Order(models.Model):
         reference = models.CharField(max_length=20, primary_key=True)
-
 
     class OrderLineItem(models.Model):
         pk = models.CompositePrimaryKey("product_id", "order_id")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1103,7 +1103,7 @@ class MultiDBInvalidationTests(BaseTestCase):
         brand.labels.add(label)
         mock_invalidate_dict.assert_called_with(mock.ANY, mock.ANY, using='slave')
 
-@unittest.skipIf(django.VERSION < (5, 2), "Feature available for django 5.2+")
+@unittest.skipIf(django.VERSION < (5, 2), 'Feature available for django 5.2+')
 class CompositePrimaryKeysTests(BaseTestCase):
     """django 5.2 add composite primary key and introduce new Lookup using Tuple."""
 
@@ -1118,6 +1118,20 @@ class CompositePrimaryKeysTests(BaseTestCase):
         # cache composite primary key filter
         qs = OrderLineItem.objects.filter(pk__in=[(product.pk, order.pk)]).cache()
         dnf_cond = dnfs(qs)
-        assert dnf_cond[item._meta.db_table][0]['product_id,order_id'] == ','.join(
-            [str(product.pk), order.pk]
-        )
+        # the dnf_cond result is like AND
+        model_dnf = dnf_cond[item._meta.db_table][0]
+        assert model_dnf['product_id'] == product.pk
+        assert model_dnf['order_id'] == order.pk
+
+        # run the query to add it in cache
+        list(qs.all())
+        with self.assertNumQueries(0):
+            items = list(qs.all())
+            assert items[0].quantity == 1
+
+        # update the quantity invalidate the cache
+        item.quantity = 2
+        item.save()
+        with self.assertNumQueries(1):
+            items = qs.all()
+            assert items[0].quantity == 2

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1103,7 +1103,7 @@ class MultiDBInvalidationTests(BaseTestCase):
         brand.labels.add(label)
         mock_invalidate_dict.assert_called_with(mock.ANY, mock.ANY, using='slave')
 
-
+@unittest.skipIf(django.VERSION < (5, 2), "Feature available for django 5.2+")
 class CompositePrimaryKeysTests(BaseTestCase):
     """django 5.2 add composite primary key and introduce new Lookup using Tuple."""
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,3 +1,4 @@
+from cacheops.tree import dnfs
 from contextlib import contextmanager
 from functools import reduce
 import operator
@@ -1101,3 +1102,22 @@ class MultiDBInvalidationTests(BaseTestCase):
         brand = Brand.objects.using('slave').create()
         brand.labels.add(label)
         mock_invalidate_dict.assert_called_with(mock.ANY, mock.ANY, using='slave')
+
+
+class CompositePrimaryKeysTests(BaseTestCase):
+    """django 5.2 add composite primary key and introduce new Lookup using Tuple."""
+
+    def test_lookup_tuple_in(self):
+        """check that dnf take into account composite primary key research.
+        notes that since django 5.2, prefetch_related query use the tupleIn lookup.
+        """
+        product = Product.objects.create(name='apple')
+        order = Order.objects.create(reference='A75H')
+        item = OrderLineItem.objects.create(product=product, order=order, quantity=1)
+
+        # cache composite primary key filter
+        qs = OrderLineItem.objects.filter(pk__in=[(product.pk, order.pk)]).cache()
+        dnf_cond = dnfs(qs)
+        assert dnf_cond[item._meta.db_table][0]['product_id,order_id'] == ','.join(
+            [str(product.pk), order.pk]
+        )


### PR DESCRIPTION
Hello,
I experienced some issues with django 5.2 with prefetch related cache. Some prefetch related items in cache were not retrieved because the dnf part of conj keys was not set. Since django 5.2, the `get_prefetch_queryset` relies on Tuple Lookup since this commit https://github.com/django/django/commit/626d77e52a3f247358514bcf51c761283968099c .

The tuple lookup is used by composite primary keys newly introduced in django 5.2, sorry I don't have time to add every tuple lookup. So, I only added the TupleIn lookup that is used by prefetch related and I added a test with a composite primary key to check that TupleIn is taken into account by dnfs.

After the review, the composite key's conj key is set like `conj:tests_orderlineitem:product_id=1&order_id=A75H`
Prefetched items with unique keys keep the same conj ie: `conj:test_order:order_id=A75H`

Thanks !
Dimitri